### PR TITLE
Fix gs:// URL building

### DIFF
--- a/auto_forensicate/uploader.py
+++ b/auto_forensicate/uploader.py
@@ -112,11 +112,12 @@ class GCSUploader(object):
     remote_path_elems = self._stamp_manager.BasePathElements(self._stamp)
     remote_path = '/'.join(remote_path_elems)
 
-    if not self._bucket_name:
-      self._bucket_name, self._base_path = self._SplitGCSUrl()
+    base_path = None
 
-    if self._base_path:
-      remote_path = '/'.join([self._base_path, remote_path])
+    self._bucket_name, base_path = self._SplitGCSUrl()
+
+    if base_path:
+      remote_path = '/'.join([base_path, remote_path])
 
     if destination:
       remote_path = '/'.join([remote_path, destination])


### PR DESCRIPTION
codefactor highlighted that base_path wasn't used as an instance attribute.
We don't provide the bucket name directly with a flag anymore, so no need to check before.