### PR TITLE
Add necessary changes for e2e tests

### DIFF
--- a/tools/remaster.sh
+++ b/tools/remaster.sh
@@ -158,7 +158,6 @@ Optional flags
   --image=IMAGE         Set the output filename to IMAGE
   --remastered_iso=ISO  Path to the remastered ISO (used if --skip_iso is
                         enabled)
-  --extra_gcs_path      Appends an path to the GCS URL
   --skip_gcs            If set, will skip GCS environment setup
   --skip_image          If set, will skip the Gift image build
   --skip_iso            If set, will skip the ISO remastering"

--- a/tools/remaster.sh
+++ b/tools/remaster.sh
@@ -26,11 +26,9 @@
 # you specify the destination with --image
 #
 # It requires the following packages, on ubuntu:
-#   gdisk genisoimage grub-efi-amd64-bin kpartx syslinux
+#   gdisk genisoimage grub-efi-amd64-bin syslinux
 #
 # gdisk and grub-efi-amd64-bin are used for the EFI booting part.
-# kpartx makes mounting the USB image file easier
-# uck is a tool to unpack/repack an LiveCD ISO.
 #
 # If you want to try the new USB image in Qemu, install the following packages:
 #   qemu-system-x86 and ovmf
@@ -46,18 +44,20 @@ FLAGS_REMASTERED_ISO=
 FLAGS_SKIP_IMAGE=false
 FLAGS_SKIP_ISO_REMASTER=false
 FLAGS_SKIP_GCS=false
+FLAGS_BUILD_TEST=false
+FLAGS_SA_JSON_PATH=""
 
 # Hardcoded paths
 readonly CURRENT_DIR=$(pwd)
-readonly CODE_DIR=$(realpath $(dirname "$0"))
+readonly CODE_DIR=$(realpath "$(dirname "$0")")
 readonly REMASTER_WORKDIR_NAME="remaster_workdir"
 readonly REMASTER_WORKDIR_PATH=$(readlink -m "${CURRENT_DIR}/${REMASTER_WORKDIR_NAME}")
 readonly REMASTER_SCRIPTS_DIR="${CODE_DIR}/remaster_scripts"
 
 readonly FORENSICATE_SCRIPT_NAME="call_auto_forensicate.sh"
 readonly FORENSICATE_SCRIPT="${REMASTER_SCRIPTS_DIR}/${FORENSICATE_SCRIPT_NAME}"
-readonly POST_UBUNTU_ROOT_SCRIPT="${REMASTER_SCRIPTS_DIR}/post-install-root.sh"
-readonly POST_UBUNTU_USER_SCRIPT="${REMASTER_SCRIPTS_DIR}/post-install-user.sh"
+POST_UBUNTU_ROOT_SCRIPT="${REMASTER_SCRIPTS_DIR}/post-install-root.sh"
+POST_UBUNTU_USER_SCRIPT="${REMASTER_SCRIPTS_DIR}/post-install-user.sh"
 readonly TMP_MNT_POINT=$(mktemp -d)
 
 # Global variables
@@ -153,9 +153,13 @@ Mandatory flags:
 
 Optional flags
   -h, --help            Show this help message
+  --sa_json_file        If provided, will use this file for the GCS service
+                        account credentials, and won't try to create one.
   --image=IMAGE         Set the output filename to IMAGE
   --remastered_iso=ISO  Path to the remastered ISO (used if --skip_iso is
                         enabled)
+  --extra_gcs_path      Appends an path to the GCS URL
+  --skip_gcs            If set, will skip GCS environment setup
   --skip_image          If set, will skip the Gift image build
   --skip_iso            If set, will skip the ISO remastering"
 }
@@ -186,7 +190,11 @@ function assert_sourceiso_flag {
     if [[ ! "${FLAGS_SOURCE_ISO}" ]]; then
       die "Please specify a source ISO to remaster with --source_iso"
     fi
-    SOURCE_ISO=$(readlink -m "${FLAGS_SOURCE_ISO}")
+    if [ -f "${FLAGS_SOURCE_ISO}" ]; then
+      SOURCE_ISO=$(readlink -m "${FLAGS_SOURCE_ISO}")
+    else
+      die "${FLAGS_SOURCE_ISO} is not found"
+    fi
   else
     if [[ ! "${FLAGS_REMASTERED_ISO}" ]]; then
       die "Please specify a remastered ISO with --remastered_iso"
@@ -207,7 +215,6 @@ function assert_image_size_flag {
     FLAGS_IMAGE_SIZE=$DEFAULT_IMAGE_SIZE
   fi
 }
-
 
 # Check FLAGS_GCS_BUCKET_NAME against Bucket Name Requirements:
 # https://cloud.google.com/storage/docs/naming#requirements
@@ -238,6 +245,17 @@ function assert_bucket_name {
 function assert_sa_name {
   if [[ ${#GCS_SA_NAME} -gt 30 ]]; then
     die "${GCS_SA_NAME} is too long for a Service Account name (>30)"
+  fi
+}
+
+# Make sure the provided service account credentials file exists and is valid
+function assert_sa_json_path {
+  if [ ! -f "${FLAGS_SA_JSON_PATH}" ] ; then
+    die "${FLAGS_SA_JSON_PATH} does not exist"
+  fi
+  if ! grep -q '"type": "service_account",' "${FLAGS_SA_JSON_PATH}" ;  then
+  #if [[ ! $(grep -q '"type": "service_account",' "${FLAGS_SA_JSON_PATH}") ]] ; then
+    die "${FLAGS_SA_JSON_PATH} does not look like a valid service account credentials JSON file"
   fi
 }
 
@@ -313,6 +331,24 @@ function parse_arguments {
         FLAGS_SKIP_GCS=true
         ;;
 
+      --sa_json_file)
+        assert_option_argument "$2" "--sa_json_file"
+        FLAGS_SA_JSON_PATH="$2"
+        shift
+        ;;
+      --sa_json_file=?*)
+        FLAGS_SA_JSON_PATH=${1#*=}
+        ;;
+      --sa_json_file=)
+          die '--sa_json_file requires a non-empty option argument.'
+        ;;
+
+      --e2e_test)
+        FLAGS_BUILD_TEST=true
+        POST_UBUNTU_ROOT_SCRIPT="${REMASTER_SCRIPTS_DIR}/e2e/post-install-root.sh"
+        POST_UBUNTU_USER_SCRIPT="${REMASTER_SCRIPTS_DIR}/e2e/post-install-user.sh"
+        ;;
+
       --source_iso)
         assert_option_argument "$2" "--source_iso"
         FLAGS_SOURCE_ISO="$2"
@@ -348,10 +384,20 @@ function parse_arguments {
     readonly FLAGS_REMASTERED_ISO=$(basename "${UBUNTU_ISO}.${REMASTERED_SUFFIX}")
   fi
 
-  readonly GCS_REMOTE_URL="gs://${FLAGS_GCS_BUCKET_NAME}/forensic_evidence"
+  readonly GCS_REMOTE_URL="gs://${FLAGS_GCS_BUCKET_NAME}/forensic_evidence/"
 
-  readonly GCS_SA_KEY_NAME="${GCS_SA_NAME}_${FLAGS_CLOUD_PROJECT_NAME}_key.json"
-  readonly GCS_SA_KEY_PATH="${REMASTER_SCRIPTS_DIR}/${GCS_SA_KEY_NAME}"
+  if [[ ! "${GCS_REMOTE_URL}" =~ ^gs://[a-zA-Z0-9_\.\-]{3,63}(/[a-zA-Z0-9_\.\-]+)+/?$ ]] ; then
+    die "${GCS_REMOTE_URL} is not a valid GCS URL"
+  fi
+
+  if [ -z "${FLAGS_SA_JSON_PATH}" ] ; then
+    readonly GCS_SA_KEY_NAME="${GCS_SA_NAME}_${FLAGS_CLOUD_PROJECT_NAME}_key.json"
+    readonly GCS_SA_KEY_PATH="${REMASTER_SCRIPTS_DIR}/${GCS_SA_KEY_NAME}"
+  else
+    assert_sa_json_path
+    readonly GCS_SA_KEY_PATH="$(readlink -m "${FLAGS_SA_JSON_PATH}")"
+    readonly GCS_SA_KEY_NAME="$(basename "${FLAGS_SA_JSON_PATH}")"
+  fi
 
 }
 
@@ -503,10 +549,13 @@ function pack_initrd {
   elif [[ -e "${unpacked_iso_dir}/install/initrd.gz" ]]; then
     initrd_file="${unpacked_iso_dir}/install/initrd.gz"
     initrd_pack_method=gzip
+  elif [[ -e "${unpacked_iso_dir}/casper/initrd" ]]; then
+    initrd_file="${unpacked_iso_dir}/casper/initrd.lz"
+    initrd_pack_method=lzma
   else
-    die "Can't find initrd.gz nor initrd.lz file"
+    die "Can't find initrd file"
   fi
-  find  | cpio -H newc -o | ${initrd_pack_method} > "${REMASTER_WORKDIR_PATH}/initrd.packed"
+  find . | cpio -H newc -o | ${initrd_pack_method} > "${REMASTER_WORKDIR_PATH}/initrd.packed"
   sudo mv -f "${REMASTER_WORKDIR_PATH}/initrd.packed" "${initrd_file}"
   popd
 }
@@ -535,10 +584,18 @@ function unpack_initrd {
   elif [[ -e "${unpacked_iso_dir}/install/initrd.gz" ]]; then
     initrd_file="${unpacked_iso_dir}/install/initrd.gz"
     initrd_pack_method=gzip
+  elif [[ -e "${unpacked_iso_dir}/casper/initrd" ]]; then
+    initrd_file="${unpacked_iso_dir}/casper/initrd"
+    initrd_pack_method=""
   else
-    die "Can't find initrd.gz nor initrd.lz file"
+    die "Can't find initrd.gz nor initrd.lz file in ${unpacked_iso_dir}"
   fi
-  cat "${initrd_file}" | "${initrd_pack_method}" -d | cpio -i
+  if [ -z "${initrd_pack_method}" ] ; then
+    # Fancy ubuntu magic
+    (cpio -id; lzma -d| cpio -id) < "${initrd_file}"
+  else
+    cat "${initrd_file}" | "${initrd_pack_method}" -d | cpio -i
+  fi
   popd
 }
 
@@ -671,8 +728,10 @@ function configure_gcs {
   msg "Preparing GCS environment"
 
   create_bucket "${FLAGS_GCS_BUCKET_NAME}"
-  create_service_account "${FLAGS_GCS_BUCKET_NAME}" "${GCS_SA_NAME}"
-  create_sa_key "${FLAGS_GCS_BUCKET_NAME}" "${GCS_SA_NAME}" "${GCS_SA_KEY_PATH}"
+  if [ -z "$FLAGS_SA_JSON_PATH" ] ; then
+    create_service_account "${FLAGS_GCS_BUCKET_NAME}" "${GCS_SA_NAME}"
+    create_sa_key "${FLAGS_GCS_BUCKET_NAME}" "${GCS_SA_NAME}" "${GCS_SA_KEY_PATH}"
+  fi
 }
 
 # This function uses a LiveCD ISO image and creates a USB bootable image.
@@ -685,7 +744,6 @@ function make_bootable_usb_image {
   local remastered_iso_path
   local kernel_name
   local loop_device
-  local loop_num
 
   remastered_iso_path=$1
 
@@ -704,12 +762,10 @@ function make_bootable_usb_image {
   sgdisk --largest-new=2 --typecode=2:8300 "${FLAGS_IMAGE_FILENAME}" # this will be the persistent partition
 
   msg "Mount the EFI partition"
-  sudo kpartx -a "${FLAGS_IMAGE_FILENAME}"
-  loop_device=$(sudo losetup -a | grep "${FLAGS_IMAGE_FILENAME}" | cut -d":" -f 1)
-  loop_num=$(basename "${loop_device}")
-  sudo mkfs.vfat "/dev/mapper/${loop_num}p1"
-  sudo mkfs.ext3 -L casper-rw "/dev/mapper/${loop_num}p2"
-  sudo mount "/dev/mapper/${loop_num}p1" "${TMP_MNT_POINT}"
+  loop_device=$(sudo losetup -fP --show "${FLAGS_IMAGE_FILENAME}")
+  sudo mkfs.vfat "${loop_device}p1"
+  sudo mkfs.ext3 -L casper-rw "${loop_device}p2"
+  sudo mount "${loop_device}p1" "${TMP_MNT_POINT}"
 
   msg "Install some EFI Magic"
   sudo mkdir -p "${TMP_MNT_POINT}/EFI/BOOT"
@@ -761,24 +817,33 @@ EOGRUB
   sudo umount "${TMP_MNT_POINT}"
 
   msg "Customize user directory"
-  sudo mount "/dev/mapper/${loop_num}p2" "${TMP_MNT_POINT}"
+  sudo mount "${loop_device}p2" "${TMP_MNT_POINT}"
   sudo mkdir -p "${TMP_MNT_POINT}/upper/home/${GIFT_USERNAME}/"
 
   pushd "${TMP_MNT_POINT}/upper/home/${GIFT_USERNAME}/"
 
-  if [[ "${FLAGS_SKIP_GCS}" == "false" ]]; then
-    sudo cp "${GCS_SA_KEY_PATH}" .
-  fi
+  sudo cp "${GCS_SA_KEY_PATH}" .
 
   pwd
   sudo cp "${FORENSICATE_SCRIPT}" "${FORENSICATE_SCRIPT_NAME}"
 
-  cat <<EOFORENSICSH | sudo tee -a "${FORENSICATE_SCRIPT_NAME}" > /dev/null
+  if $FLAGS_BUILD_TEST ; then
+    cat <<EOFORENSICSH | sudo tee -a "${FORENSICATE_SCRIPT_NAME}" > /dev/null
 sudo "${AUTO_FORENSIC_SCRIPT_NAME}" \
   --gs_keyfile="../${GCS_SA_KEY_NAME}" \
   --logging stdout \
-  --acquire all "${GCS_REMOTE_URL}/" ${AF_ARG}
+  --acquire all --disk sdb "${GCS_REMOTE_URL}/"
 EOFORENSICSH
+
+  else
+
+    cat <<EOFORENSICSH | sudo tee -a "${FORENSICATE_SCRIPT_NAME}" > /dev/null
+sudo "${AUTO_FORENSIC_SCRIPT_NAME}" \
+  --gs_keyfile="../${GCS_SA_KEY_NAME}" \
+  --logging stdout \
+  --acquire all "${GCS_REMOTE_URL}/"
+EOFORENSICSH
+  fi
 
   if [[ -f "${POST_UBUNTU_USER_SCRIPT}" ]] ; then
     . "${POST_UBUNTU_USER_SCRIPT}"
@@ -792,10 +857,14 @@ EOFORENSICSH
   sudo chown -R 999:999 "${TMP_MNT_POINT}/upper/home/${GIFT_USERNAME}"
 
   msg "Cleaning up"
-  sudo rm "${GCS_SA_KEY_PATH}"
+  if [[ "${FLAGS_SKIP_GCS}" == "false" ]]; then
+    if [[ ! -z "${FLAGS_SA_JSON_PATH}" ]] ; then
+      sudo rm "${GCS_SA_KEY_PATH}"
+    fi
+  fi
   sudo umount "${TMP_MNT_POINT}"
   rmdir "${TMP_MNT_POINT}"
-  sudo kpartx -d "${FLAGS_IMAGE_FILENAME}"
+  sudo losetup -d "${loop_device}"
 }
 
 function main {
@@ -805,9 +874,7 @@ function main {
   check_available_space "${REMASTER_WORKDIR_PATH}"
   check_packages gdisk
   check_packages genisoimage
-  check_packages grub2-common
   check_packages grub-efi-amd64-bin
-  check_packages kpartx
   check_packages squashfs-tools
   check_packages syslinux
 
@@ -848,8 +915,8 @@ if [[ -d '${CURRENT_DIR}' ]]; then
   cd ${CURRENT_DIR}
   mountpoint -q '${TMP_MNT_POINT}' && sudo -n umount '${TMP_MNT_POINT}'
   if [[ -f '${FLAGS_IMAGE_FILENAME}' ]]; then
-    echo sudo -n kpartx -d '${FLAGS_IMAGE_FILENAME}'
-    sudo -n kpartx -d '${FLAGS_IMAGE_FILENAME}'
+    loop_device=$(losetup -O NAME --noheadings -j '${FLAGS_IMAGE_FILENAME}')
+    sudo losetup -d '${loop_device}'
   fi
   if [[ -d '${TMP_MNT_POINT}' ]] ; then
     rmdir '${TMP_MNT_POINT}'

--- a/tools/remaster_scripts/e2e/post-install-root.sh
+++ b/tools/remaster_scripts/e2e/post-install-root.sh
@@ -32,11 +32,10 @@ function install_forensication_tools {
 }
 
 function install_basic_pkg {
-  readonly local COMMON_UTILS=( git jq python-pip pv zenity )
-  readonly local WIRELESS_PKG=( firmware-b43-installer bcmwl-kernel-source )
+  readonly local COMMON_UTILS=( git jq python-pip pv openssh-server zenity )
 
   apt-get -y update
-  apt-get -y install "${COMMON_UTILS[@]}" "${WIRELESS_PKG[@]}"
+  apt-get -y install "${COMMON_UTILS[@]}"
 
   echo "PasswordAuthentication no" >>  /etc/ssh/sshd_config
 }
@@ -60,21 +59,6 @@ function ubuntu_fix_systemd {
   apt-get -y install libnss-resolve
 }
 
-function ubuntu_fix_mbp {
-
-  # This is installing SPI drivers for the keyboard & mousepads on
-  # MacBook 2016 (with touchbar)
-  apt-get -y install dkms
-  git clone https://github.com/cb22/macbook12-spi-driver.git /usr/src/applespi-0.1
-
-  # We need to install for the kernel of the OS we're chrooted in, not the one
-  # that's currently running on our workstation.
-  # Ubuntu Live CD should only have one kernel installed, so this should work.
-  dkms install -m applespi -v 0.1 -k "$(basename /lib/modules/*)"
-  echo -e "\napplespi\nintel_lpss_pci\nspi_pxa2xx_platform" >> /etc/initramfs-tools/modules
-  update-initramfs -u
-}
-
 function ignore_chipsec_logs {
   # Chipsec generates a ton of logs which can fill up the local storage
   echo -e ":msg, contains, \"IOCTL_RDMMIO\" stop\n\
@@ -96,4 +80,3 @@ ignore_chipsec_logs
 install_basic_pkg
 install_forensication_tools
 ubuntu_remove_packages
-ubuntu_fix_mbp

--- a/tools/remaster_scripts/e2e/post-install-user.sh
+++ b/tools/remaster_scripts/e2e/post-install-user.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Does customization for the xubuntu user
+# The script is run as sudoer on your workstation, permissions are fixed
+# later.
+
+function add_test_ssh_key {
+  sudo mkdir .ssh
+  echo "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHx26PEzEj5WIZDP/Actr4LruAiIFbVP4hS8ANBrcnnH e2etests" | sudo tee -a .ssh/authorized_keys
+}
+
+add_test_ssh_key


### PR DESCRIPTION
Some changes needed for running the scripts as part of end-to-end test:
* Add some extra flags to the remaster.sh script:
  * --e2e_tests (not in --help) to generate an image suitable for e2e-tests (see below)
  * --sa_json_file  to specify a Service Account credentials file to use
* bionic is also added to the versions of Ubuntu that need extra systemd massaging (and a specific lzma compression for the initrd file)
* move away from kpartx, and use basic losetup commands instead 
* If the --e2e_tests flag is passed, we run scripts from the "e2e" directory, which does the same as the normal ones except:
  * We don't try very hard to make Apple wifi chipset work
  * The only user customization is pushing a default SSH public key

This is a split from #16