### PR TITLE
Make the code MacOS compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install:
     - pip install -r requirements.txt
     - pip install coverage
     - git clone https://github.com/google/macops
-    - cd macops/gmacpyutil ; python setup.py install
+    - cd macops/gmacpyutil ; python setup.py install; cd ..
 script:
     - export BOTO_CONFIG=/dev/null
     - coverage run run_tests.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install:
     - pip install -r requirements.txt
     - pip install coverage
     - git clone https://github.com/google/macops
-    - cd macops/gmacpyutil ; python setup.py install; cd ..
+    - cd macops/gmacpyutil ; python setup.py install; cd ../..
 script:
     - export BOTO_CONFIG=/dev/null
     - coverage run run_tests.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ python:
 install:
     - pip install -r requirements.txt
     - pip install coverage
+    - git clone https://github.com/google/macops
+    - cd macops/gmacpyutil ; python setup.py install
 script:
     - export BOTO_CONFIG=/dev/null
     - coverage run run_tests.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ python:
 install:
     - pip install -r requirements.txt
     - pip install coverage
-    - git clone https://github.com/google/macops
-    - cd macops/gmacpyutil ; python setup.py install; cd ../..
 script:
     - export BOTO_CONFIG=/dev/null
     - coverage run run_tests.py

--- a/auto_forensicate/__init__.py
+++ b/auto_forensicate/__init__.py
@@ -11,4 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/auto_forensicate/auto_acquire.py
+++ b/auto_forensicate/auto_acquire.py
@@ -22,12 +22,6 @@ import json
 import logging
 import sys
 import time
-from auto_forensicate import errors
-from auto_forensicate import uploader
-from auto_forensicate.recipes import disk
-from auto_forensicate.recipes import firmware
-from auto_forensicate.recipes import sysinfo
-from auto_forensicate.stamp import manager
 
 import gcs_oauth2_boto_plugin  # pylint: disable=unused-import
 from google.cloud import logging as google_logging
@@ -36,6 +30,13 @@ from google.cloud.logging.handlers import setup_logging as setup_gcp_logging
 from google.oauth2 import service_account
 from progress.bar import IncrementalBar
 from progress.spinner import Spinner
+
+from auto_forensicate import errors
+from auto_forensicate import uploader
+from auto_forensicate.recipes import disk
+from auto_forensicate.recipes import firmware
+from auto_forensicate.recipes import sysinfo
+from auto_forensicate.stamp import manager
 
 VALID_RECIPES = {
     'disk': disk.DiskRecipe,
@@ -238,7 +239,7 @@ class AutoForensicate(object):
       return uploader.GCSUploader(
           options.destination, options.gs_keyfile, client_id, stamp_manager)
 
-    return
+    return None
 
   def ParseArguments(self, args):
     """Parses the arguments.

--- a/auto_forensicate/hostinfo.py
+++ b/auto_forensicate/hostinfo.py
@@ -122,3 +122,21 @@ def GetUdevadmInfo(device_name):
 def GetTime():
   """Returns the current time as a iso string."""
   return time.strftime('%Y%m%d-%H%M%S', time.gmtime())
+
+
+def Which(cmd):
+  """Searches for a binary in the current PATH environment variable.
+
+  Args:
+    cmd(str): the binary to search for.
+  Returns:
+    str: the first found path to a binary with the same name, or None.
+  """
+  path_list = os.environ.get('PATH', os.defpath).split(os.pathsep)
+  for directory in path_list:
+    name = os.path.join(directory, cmd)
+    if os.path.isdir(name):
+      continue
+    if os.path.exists(name) and os.access(name, os.F_OK | os.X_OK):
+      return name
+  return None

--- a/auto_forensicate/macdisk.py
+++ b/auto_forensicate/macdisk.py
@@ -24,7 +24,7 @@ class MacDiskError(Exception):
 
 
 def _DictFromSubprocess(command):
-  """returns a dict based upon a subprocess call with a -plist argument.
+  """Returns a dict based upon a subprocess call with a -plist argument.
 
   Args:
     command: the command to be executed as a list.
@@ -53,7 +53,7 @@ def _DictFromSubprocess(command):
 
 
 def _DictFromDiskutilInfo(deviceid):
-  """calls diskutil info for a specific device id.
+  """Calls diskutil info for a specific device id.
 
   Args:
     deviceid(string): a given device id for a disk like object.
@@ -73,7 +73,7 @@ def _DictFromDiskutilList():
     dict: resulting plist output
   """
 
-  command = ["/usr/sbin/diskutil", "list", "-plist"]
+  command = ['/usr/sbin/diskutil', 'list', '-plist']
   return _DictFromSubprocess(command)
 
 

--- a/auto_forensicate/macdisk.py
+++ b/auto_forensicate/macdisk.py
@@ -1,0 +1,140 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Helper functions to handle Mac OS information."""
+
+import plistlib
+import xml.parsers.expat
+import subprocess
+
+class MacDiskError(Exception):
+  """Module specific exception class."""
+  pass
+
+def RunProcess(cmd):
+  """Executes cmd using suprocess.
+
+  Args:
+    cmd: An array of strings as the command to run
+  Returns:
+    Tuple: two strings and an integer: (stdout, stderr, returncode);
+    stdout/stderr may also be None. If the process is set to launch in
+    background mode, an instance of <subprocess.Popen object> is
+    returned, in order to be able to read from its pipes *and* use poll() to
+    check when it is finished.
+  """
+  try:
+    task = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+  except OSError as e:
+    raise OSError('Could not execute: %s' % e.strerror)
+  (stdout, stderr) = task.communicate()
+  return (stdout, stderr, task.returncode)
+
+def _DictFromSubprocess(command):
+  """returns a dict based upon a subprocess call with a -plist argument.
+
+  Args:
+    command: the command to be executed as a list
+  Returns:
+    dict: dictionary from command output
+  """
+
+  task = {}
+
+  (task['stdout'], task['stderr'], task['returncode']) = RunProcess(command)
+
+  if task['returncode'] is not 0:
+    raise MacDiskError(
+        'Error running command: {0}, stderr: {1}' .format(
+            command, task['stderr']))
+  else:
+    try:
+      return plistlib.readPlistFromString(task['stdout'])
+    except xml.parsers.expat.ExpatError:
+      raise MacDiskError(
+          'Error creating plist from output: {0}'.format(task['stdout']))
+
+def _DictFromDiskutilInfo(deviceid):
+  """calls diskutil info for a specific device id.
+
+  Args:
+    deviceid: a given device id for a disk like object
+  Returns:
+    info: dictionary from resulting plist output
+  Raises:
+    MacDiskError: deviceid is invalid
+  """
+  # Do we want to do this? can trigger optical drive noises...
+  if deviceid not in PartitionDeviceIds():
+    raise MacDiskError("%s is not a valid disk id" % deviceid)
+  else:
+    command = ["/usr/sbin/diskutil", "info", "-plist", deviceid]
+    return _DictFromSubprocess(command)
+
+def _DictFromDiskutilList():
+  """calls diskutil list -plist and returns as dict."""
+
+  command = ["/usr/sbin/diskutil", "list", "-plist"]
+  return _DictFromSubprocess(command)
+
+def PartitionDeviceIds():
+  """Returns a list of all device ids that are partitions."""
+  try:
+    return _DictFromDiskutilList()["AllDisks"]
+  except KeyError:
+    # TODO(user): fix errors to actually provide info...
+    raise MacDiskError("Unable to list all partitions.")
+
+class Disk(object):
+  """Represents a Mac disk object.
+
+  Note that this also is used for currently mounted disk images as they
+  really are just 'disks'. Mostly. Can take device ids of the form "disk1" or
+  of the form "/dev/disk1".
+  """
+
+  def __init__(self, deviceid):
+    if deviceid.startswith("/dev/"):
+      deviceid = deviceid.replace("/dev/", "", 1)
+    self.deviceid = deviceid
+    self.Refresh()
+
+  def Refresh(self):
+    """convenience attrs for direct querying really."""
+
+    self._attributes = _DictFromDiskutilInfo(self.deviceid)
+    # We iterate over all known keys, yes this includes DeviceIdentifier
+    # even though we"re using deviceid internally for init.
+    # This is why the rest of the code has gratuitous use of
+    # disable-msg=E1101 due to constructing the attributes this way.
+    keys = ["Content", "Internal", "CanBeMadeBootableRequiresDestroy",
+            "MountPoint", "DeviceNode", "SystemImage", "CanBeMadeBootable",
+            "SupportsGlobalPermissionsDisable", "VolumeName",
+            "DeviceTreePath", "DeviceIdentifier", "VolumeUUID", "Bootable",
+            "BusProtocol", "Ejectable", "MediaType", "RAIDSlice",
+            "FilesystemName", "RAIDMaster", "WholeDisk", "FreeSpace",
+            "TotalSize", "GlobalPermissionsEnabled", "SMARTStatus",
+            "Writable", "ParentWholeDisk", "MediaName"]
+
+    for key in keys:
+      try:
+        attribute = key.lower().replace(" ", "")
+        setattr(self, attribute, self._attributes[key])
+      except KeyError:  # not all objects have all these attributes
+        pass
+
+    if self.busprotocol == "Disk Image":  # pylint: disable=no-member
+      self.diskimage = True
+    else:
+      self.diskimage = False

--- a/auto_forensicate/macdisk.py
+++ b/auto_forensicate/macdisk.py
@@ -14,9 +14,8 @@
 # limitations under the License.
 """Helper functions to handle Mac OS information."""
 
-import plistlib
-import xml.parsers.expat
 import subprocess
+import biplist
 
 class MacDiskError(Exception):
   """Module specific exception class."""
@@ -29,10 +28,7 @@ def RunProcess(cmd):
     cmd: An array of strings as the command to run
   Returns:
     Tuple: two strings and an integer: (stdout, stderr, returncode);
-    stdout/stderr may also be None. If the process is set to launch in
-    background mode, an instance of <subprocess.Popen object> is
-    returned, in order to be able to read from its pipes *and* use poll() to
-    check when it is finished.
+    stdout/stderr may also be None.
   """
   try:
     task = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -60,8 +56,8 @@ def _DictFromSubprocess(command):
             command, task['stderr']))
   else:
     try:
-      return plistlib.readPlistFromString(task['stdout'])
-    except xml.parsers.expat.ExpatError:
+      return biplist.readPlistFromString(task['stdout'])
+    except (biplist.InvalidPlistException, biplist.NotBinaryPlistException):
       raise MacDiskError(
           'Error creating plist from output: {0}'.format(task['stdout']))
 

--- a/auto_forensicate/macdisk.py
+++ b/auto_forensicate/macdisk.py
@@ -44,12 +44,12 @@ def _DictFromSubprocess(command):
   if task.returncode is not 0:
     raise MacDiskError(
         'Error running command: {0}, stderr: {1}' .format(command, stderr))
-  else:
-    try:
-      return biplist.readPlistFromString(stdout)
-    except (biplist.InvalidPlistException, biplist.NotBinaryPlistException):
-      raise MacDiskError(
-          'Error creating plist from output: {0}'.format(stdout))
+
+  try:
+    return biplist.readPlistFromString(stdout)
+  except (biplist.InvalidPlistException, biplist.NotBinaryPlistException):
+    raise MacDiskError(
+        'Error creating plist from output: {0}'.format(stdout))
 
 
 def _DictFromDiskutilInfo(deviceid):

--- a/auto_forensicate/macdisk.py
+++ b/auto_forensicate/macdisk.py
@@ -113,7 +113,7 @@ class Disk(object):
 
     self._attributes = _DictFromDiskutilInfo(self.deviceid)
     # These are the keys we are interested in
-    keys = ['Internal', 'BusProtocol', 'VirtualOrPhysical']
+    keys = ['Internal', 'DeviceIdentifier', 'BusProtocol', 'VirtualOrPhysical']
 
     for key in keys:
       try:

--- a/auto_forensicate/macdisk.py
+++ b/auto_forensicate/macdisk.py
@@ -96,6 +96,21 @@ def PartitionDeviceIds():
     # TODO(user): fix errors to actually provide info...
     raise MacDiskError("Unable to list all partitions.")
 
+def WholeDiskDeviceIds():
+  """Returns a list of device ids for all whole disks."""
+  try:
+    return _DictFromDiskutilList()["WholeDisks"]
+  except KeyError:
+    # TODO(user): fix errors to actually provide info...
+    raise MacDiskError("Unable to list all partitions.")
+
+def WholeDisks():
+  """Returns a list of all disk objects that are whole disks."""
+  wholedisks = []
+  for deviceid in WholeDiskDeviceIds():
+    wholedisks.append(Disk(deviceid))
+  return wholedisks
+
 class Disk(object):
   """Represents a Mac disk object.
 

--- a/auto_forensicate/macdisk.py
+++ b/auto_forensicate/macdisk.py
@@ -113,7 +113,8 @@ class Disk(object):
 
     self._attributes = _DictFromDiskutilInfo(self.deviceid)
     # These are the keys we are interested in
-    keys = ['Internal', 'DeviceIdentifier', 'BusProtocol', 'VirtualOrPhysical']
+    keys = ['Internal', 'DeviceIdentifier', 'BusProtocol', 'VirtualOrPhysical',
+            'DeviceIdentifier', 'TotalSize']
 
     for key in keys:
       try:

--- a/auto_forensicate/recipes/__init__.py
+++ b/auto_forensicate/recipes/__init__.py
@@ -12,4 +12,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/auto_forensicate/recipes/base.py
+++ b/auto_forensicate/recipes/base.py
@@ -19,10 +19,11 @@ from __future__ import unicode_literals
 import logging
 import os
 from io import BytesIO
-import six
 import shutil
 import subprocess
+import sys
 import tempfile
+import six
 
 
 class BaseArtifact(object):
@@ -243,6 +244,7 @@ class BaseRecipe(object):
     Raises:
       ValueError: if the name parameter is None.
     """
+    self._platform = sys.platform
     self._workdir = None
     if name:
       self.name = name

--- a/auto_forensicate/recipes/disk.py
+++ b/auto_forensicate/recipes/disk.py
@@ -37,7 +37,7 @@ class DiskArtifact(base.BaseArtifact):
     size (int): the size of the artifact, in bytes.
   """
 
-  _DD_BINARY = '/usr/bin/dcfldd'
+  _DD_BINARY = 'dcfldd'
   _DD_OPTIONS = ['hash=md5,sha1', 'bs=2M', 'conv=noerror', 'hashwindow=128M']
 
   def __init__(self, path, size):
@@ -71,8 +71,12 @@ class DiskArtifact(base.BaseArtifact):
     Returns:
       list: the argument list for the dd command
     """
+    dd_binary = hostinfo.Which(self._DD_BINARY)
+    if not dd_binary:
+      raise errors.RecipeException(
+          'Could not find \'{0}\''.format(self._DD_BINARY))
     command = [
-        self._DD_BINARY, 'if={0:s}'.format(self._path),
+        dd_binary, 'if={0:s}'.format(self._path),
         'hashlog={0:s}'.format(self.hashlog_filename)]
     command.extend(self._DD_OPTIONS)
     return command
@@ -146,9 +150,6 @@ class MacDiskArtifact(DiskArtifact):
     remote_path (str): the path to the artifact in the remote storage.
     size (int): the size of the artifact, in bytes.
   """
-
-  # When installed with HomeBrew
-  _DD_BINARY = '/usr/local/bin/dcfldd'
 
   def __init__(self, path, size):
     """Initializes a MacDiskArtifact object.

--- a/auto_forensicate/recipes/disk.py
+++ b/auto_forensicate/recipes/disk.py
@@ -181,13 +181,13 @@ class MacDiskArtifact(DiskArtifact):
     if self._IsUsb():
       # We ignore USB to try to avoid copying the GiftStick itself.
       return False
-    if self._IsUsb():
-      return False
     if self._macdisk.internal and (
+        # TODO: this needs more research on how to autodetect "interesting"
+        # disks to copy on MacOS.
         # pylint: disable=protected-access
         self._macdisk._attributes['VirtualOrPhysical'] != 'Virtual'):
-      return False
-    return True
+      return True
+    return False
 
 class LinuxDiskArtifact(DiskArtifact):
   """The DiskArtifact class.

--- a/auto_forensicate/recipes/disk.py
+++ b/auto_forensicate/recipes/disk.py
@@ -25,6 +25,14 @@ from auto_forensicate import hostinfo
 from auto_forensicate.recipes import base
 from auto_forensicate.ux import gui
 
+try:
+  # This is not in pip, can be installed from:
+  # https://github.com/google/macops/tree/master/gmacpyutil
+  # If not present, code should still run on a Linux machine.
+  from gmacpyutil import macdisk
+except ImportError:
+  pass
+
 
 class DiskArtifact(base.BaseArtifact):
   """The DiskArtifact class.
@@ -36,18 +44,19 @@ class DiskArtifact(base.BaseArtifact):
     size (int): the size of the artifact, in bytes.
   """
 
-  _DD_BINARY = '/usr/bin/dcfldd'
   _DD_OPTIONS = ['hash=md5,sha1', 'bs=2M', 'conv=noerror', 'hashwindow=128M']
 
   def __init__(self, path, size):
     """Initializes a DiskArtifact object.
+
+    Only supported implementations are MacOS and Linux.
 
     Args:
       path(str): the path to the disk.
       size(str): the size of the disk.
 
     Raises:
-      ValueError: if path is None, doesn't start with '/dev' or size is =< 0.
+      valueerror: if path is none, doesn't start with '/dev' or size is =< 0.
     """
     super(DiskArtifact, self).__init__(os.path.basename(path))
     if not path.startswith('/dev'):
@@ -61,8 +70,6 @@ class DiskArtifact(base.BaseArtifact):
       raise ValueError('Disk size must be an integer > 0')
     self.hashlog_filename = '{0:s}.hash'.format(self.name)
     self.remote_path = 'Disks/{0:s}.image'.format(self.name)
-
-    self._udevadm_metadata = None
 
   def _GenerateDDCommand(self):
     """Builds the DD command to run on the disk.
@@ -123,23 +130,90 @@ class DiskArtifact(base.BaseArtifact):
       raise subprocess.CalledProcessError(code, self._DD_BINARY, error)
     return error
 
+  def GetDescription(self):
+    """Get a human readable description about the device.
+
+    Returns:
+      str: the description
+    """
+    return 'Name: {0} (Size: {1:d})'.format(self.name, self.size)
+
   def ProbablyADisk(self):
     """Returns whether this is probably one of the system's internal disks."""
-    if self._IsFloppy():
-      return False
-    if self._IsUsb():
-      # We ignore USB to try to avoid copying the GiftStick itself.
-      return False
     return True
 
-  def _IsFloppy(self):
-    """Whether this block device is a floppy disk."""
-    # see https://www.kernel.org/doc/html/latest/admin-guide/devices.html
-    return self.GetUdevadmProperty('MAJOR') == '2'
+
+class MacDiskArtifact(DiskArtifact):
+  """The MacDiskArtifact class.
+
+  Attributes:
+    hashlog_filename (str): where dcfldd will store the hashes.
+    name (str): the name of the artifact.
+    remote_path (str): the path to the artifact in the remote storage.
+    size (int): the size of the artifact, in bytes.
+  """
+
+  # When installed with HomeBrew
+  _DD_BINARY = '/usr/local/bin/dcfldd'
+
+  def __init__(self, path, size):
+    """Initializes a MacDiskArtifact object.
+
+    Only supported implementations are MacOS and Linux.
+
+    Args:
+      path(str): the path to the disk.
+      size(str): the size of the disk.
+
+    Raises:
+      valueerror: if path is none, doesn't start with '/dev' or size is =< 0.
+    """
+    super(MacDiskArtifact, self).__init__(path, size)
+    self._macdisk = macdisk.Disk(self.name)
 
   def _IsUsb(self):
     """Whether this device is connected on USB."""
-    return self.GetUdevadmProperty('ID_BUS') == 'usb'
+    return self._macdisk.busprotocol == 'USB'
+
+  def ProbablyADisk(self):
+    """Returns whether this is probably one of the system's internal disks."""
+    if self._IsUsb():
+      # We ignore USB to try to avoid copying the GiftStick itself.
+      return False
+    if self._IsUsb():
+      return False
+    if self._macdisk.internal and (
+        # pylint: disable=protected-access
+        self._macdisk._attributes['VirtualOrPhysical'] != 'Virtual'):
+      return False
+    return True
+
+class LinuxDiskArtifact(DiskArtifact):
+  """The DiskArtifact class.
+
+  Attributes:
+    hashlog_filename (str): where dcfldd will store the hashes.
+    name (str): the name of the artifact.
+    remote_path (str): the path to the artifact in the remote storage.
+    size (int): the size of the artifact, in bytes.
+  """
+
+  _DD_BINARY = '/usr/bin/dcfldd'
+
+  def __init__(self, path, size):
+    """Initializes a LinuxDiskArtifact object.
+
+    Args:
+      path(str): the path to the disk.
+      size(str): the size of the disk.
+
+    Raises:
+      valueerror: if path is none, doesn't start with '/dev' or size is =< 0.
+    """
+
+    super(LinuxDiskArtifact, self).__init__(path, size)
+
+    self._udevadm_metadata = None
 
   def GetDescription(self):
     """Get a human readable description about the device.
@@ -147,18 +221,18 @@ class DiskArtifact(base.BaseArtifact):
     Returns:
       str: the description
     """
-    model = self.GetUdevadmProperty('ID_MODEL')
+    model = self._GetUdevadmProperty('ID_MODEL')
     if self._IsFloppy():
       model = 'Floppy Disk'
     if not model:
-      model = self.GetUdevadmProperty('ID_SERIAL')
+      model = self._GetUdevadmProperty('ID_SERIAL')
     connection = '(internal)'
     if self._IsUsb():
-      model = '{0} {1}'.format(self.GetUdevadmProperty('ID_VENDOR'), model)
+      model = '{0} {1}'.format(self._GetUdevadmProperty('ID_VENDOR'), model)
       connection = '(usb)'
     return '{0}: {1} {2}'.format(self.name, model, connection)
 
-  def GetUdevadmProperty(self, prop):
+  def _GetUdevadmProperty(self, prop):
     """Get a udevadm property.
 
     Args:
@@ -171,12 +245,41 @@ class DiskArtifact(base.BaseArtifact):
       self._udevadm_metadata = hostinfo.GetUdevadmInfo(self.name)
     return self._udevadm_metadata.get(prop, None)
 
+  def ProbablyADisk(self):
+    """Returns whether this is probably one of the system's internal disks."""
+    if self._IsFloppy():
+      return False
+    if self._IsUsb():
+      # We ignore USB to try to avoid copying the GiftStick itself.
+      return False
+    return True
+
+  def _IsFloppy(self):
+    """Whether this block device is a floppy disk."""
+    # see https://www.kernel.org/doc/html/latest/admin-guide/devices.html
+    return self._GetUdevadmProperty('MAJOR') == '2'
+
+  def _IsUsb(self):
+    """Whether this device is connected on USB."""
+    return self._GetUdevadmProperty('ID_BUS') == 'usb'
+
 
 class DiskRecipe(base.BaseRecipe):
   """The DiskRecipe class.
 
   This Recipe acquires the raw image of all disks on the system.
   """
+
+  def __init__(self, name, options=None):
+    """Initializes a DiskRecipe object.
+
+    Args:
+      name (str): the name of the artifact.
+
+    Raises:
+      ValueError: if the name is empty or None.
+    """
+    super(DiskRecipe, self).__init__(name, options=options)
 
   def _GetLsblkDict(self):
     """Calls lsblk.
@@ -188,35 +291,93 @@ class DiskRecipe(base.BaseRecipe):
         ['/bin/lsblk', '-J', '--bytes', '-o', '+UUID,FSTYPE,SERIAL'])
     return json.loads(lsblk_output)
 
-  def _ListDisks(self, all_devices=False, names=None):
+  def _ListDisksMac(self):
     """Lists disks connected to the machine.
 
-    Args:
-      all_devices(bool): whether to also list devices that aren't internal to
-        the system's (ie: removable media).
-      names(list(str)): list of disk names (ie: ['sda', 'sdc']) to acquire.
+    Returns:
+      list(MacDiskArtifact): a list of disks.
+    """
+    disk_list = []
+    for mac_disk in macdisk.WholeDisks():
+      disk_name = mac_disk.deviceidentifier
+      disk_size = mac_disk.totalsize
+      disk = MacDiskArtifact(os.path.join('/dev', disk_name), disk_size)
+      disk_list.append(disk)
+    return disk_list
+
+  def _ListDisksLinux(self):
+    """Lists disks connected to the machine.
 
     Returns:
-      list(DiskArtifact): a list of disks.
-
-    Raises:
-      errors.RecipeException: when no disk could be detected.
+      list(LinuxDiskArtifact): a list of disks.
     """
     lsblk_dict = self._GetLsblkDict()
     disk_list = []
     for blockdevice in lsblk_dict.get('blockdevices', None):
       if blockdevice.get('type') == 'disk':
         disk_name = blockdevice.get('name')
-        if names:
-          if disk_name not in names:
-            continue
         disk_size_str = blockdevice.get('size')
         disk_size = int(disk_size_str)
-        disk = DiskArtifact(os.path.join('/dev', disk_name), disk_size)
-        if all_devices or disk.ProbablyADisk():
-          disk_list.append(disk)
+        disk = LinuxDiskArtifact(os.path.join('/dev', disk_name), disk_size)
+        disk_list.append(disk)
+    return disk_list
+
+  def _ListDisks(self, all_devices=False, names=None):
+    """
+
+    Args:
+      all_devices(bool): whether to also list devices that aren't internal to
+        the system's (ie: removable media).
+      names(list(str)): list of disk names (ie: ['sda', 'sdc']) to acquire.
+    """
+    disk_list = []
+    if self._platform == 'darwin':
+      disk_list = self._ListDisksMac()
+    else:
+      disk_list = self._ListDisksLinux()
+
     # We order the list by size, descending.
-    return sorted(disk_list, reverse=True, key=lambda disk: disk.size)
+    disk_list = sorted(disk_list, reverse=True, key=lambda disk: disk.size)
+    if names:
+      return [disk for disk in disk_list if disk.name in names]
+    if not all_devices:
+      # We resort to guessing
+      return [disk for disk in disk_list if disk.ProbablyADisk()]
+    return disk_list
+
+  def _GetListDisksArtifact(self):
+    """Generates a StringArtifact containing information about all disks.
+
+    Returns:
+      StringArtifact: the artifact.
+    """
+    if self._platform == 'darwin':
+      #pylint: disable=protected-access
+      diskutil_artifact = base.StringArtifact(
+          'Disks/diskutil.txt', json.dumps(
+              [md._attributes for md in macdisk.WholeDisks()]))
+      return diskutil_artifact
+
+    lsblk_artifact = base.StringArtifact(
+        'Disks/lsblk.txt', json.dumps(self._GetLsblkDict()))
+    return lsblk_artifact
+
+  def _GetDiskInfoArtifact(self, disk):
+    """Returns an StringArtifact containing information about a disk being
+    copied.
+
+    Args:
+      disk(DiskArtifact): the disk object to get info from.
+    """
+    if self._platform == 'darwin':
+      # TODO
+      return None
+
+    #pylint: disable=protected-access
+    udevadm_artifact = base.StringArtifact(
+        'Disks/{0:s}.udevadm.txt'.format(disk.name),
+        disk._GetUdevadmProperty('udevadm_text_output'))
+    return udevadm_artifact
 
   def GetArtifacts(self):
     """Selects the Artifacts to acquire.
@@ -243,12 +404,10 @@ class DiskRecipe(base.BaseRecipe):
     if not disks_to_collect:
       raise errors.RecipeException('No disk to collect')
 
-    lsblk_artifact = base.StringArtifact(
-        'Disks/lsblk.txt', json.dumps(self._GetLsblkDict()))
+    disk_list_artifact = self._GetListDisksArtifact()
+    artifacts.append(disk_list_artifact)
+
     for disk in disks_to_collect:
-      udevadm_artifact = base.StringArtifact(
-          'Disks/{0:s}.udevadm.txt'.format(disk.name),
-          disk.GetUdevadmProperty('udevadm_text_output'))
 
       hashlog_artifact = base.FileArtifact(disk.hashlog_filename)
       hashlog_artifact.remote_path = 'Disks/{0:s}'.format(
@@ -256,8 +415,9 @@ class DiskRecipe(base.BaseRecipe):
 
       # It is necessary for the DiskArtifact to be appended before the
       # hashlog, as the hashlog is generated when dcfldd completes.
-      artifacts.append(udevadm_artifact)
-      artifacts.append(lsblk_artifact)
+      disk_info_artifact = self._GetDiskInfoArtifact(disk)
+      if disk_info_artifact:
+        artifacts.append(disk_info_artifact)
       artifacts.append(disk)
       artifacts.append(hashlog_artifact)
     return artifacts

--- a/auto_forensicate/recipes/disk.py
+++ b/auto_forensicate/recipes/disk.py
@@ -50,7 +50,7 @@ class DiskArtifact(base.BaseArtifact):
       size(str): the size of the disk.
 
     Raises:
-      valueerror: if path is none, doesn't start with '/dev' or size is =< 0.
+      ValueError: if path is none, doesn't start with '/dev' or size is =< 0.
     """
     super(DiskArtifact, self).__init__(os.path.basename(path))
     if not path.startswith('/dev'):
@@ -160,7 +160,7 @@ class MacDiskArtifact(DiskArtifact):
       size(str): the size of the disk.
 
     Raises:
-      valueerror: if path is none, doesn't start with '/dev' or size is =< 0.
+      ValueError: if path is none, doesn't start with '/dev' or size is =< 0.
     """
     super(MacDiskArtifact, self).__init__(path, size)
     self._macdisk = macdisk.Disk(self.name)
@@ -199,7 +199,7 @@ class LinuxDiskArtifact(DiskArtifact):
       size(str): the size of the disk.
 
     Raises:
-      valueerror: if path is none, doesn't start with '/dev' or size is =< 0.
+      ValueError: if path is none, doesn't start with '/dev' or size is =< 0.
     """
 
     super(LinuxDiskArtifact, self).__init__(path, size)
@@ -207,7 +207,7 @@ class LinuxDiskArtifact(DiskArtifact):
     self._udevadm_metadata = None
 
   def GetDescription(self):
-    """Get a human readable description about the device.
+    """Get a human readable description of the device.
 
     Returns:
       str: the description
@@ -261,17 +261,6 @@ class DiskRecipe(base.BaseRecipe):
   This Recipe acquires the raw image of all disks on the system.
   """
 
-  def __init__(self, name, options=None):
-    """Initializes a DiskRecipe object.
-
-    Args:
-      name (str): the name of the artifact.
-
-    Raises:
-      ValueError: if the name is empty or None.
-    """
-    super(DiskRecipe, self).__init__(name, options=options)
-
   def _GetLsblkDict(self):
     """Calls lsblk.
 
@@ -315,12 +304,12 @@ class DiskRecipe(base.BaseRecipe):
 
   def _ListDisks(self, all_devices=False, names=None):
     """Between all disks connected to the machine, selects the one we want to
-    acquired.
+    acquire.
 
     Args:
       all_devices(bool): whether to also list devices that aren't internal to
         the system's (ie: removable media).
-      names(list(str)): list of disk names (ie: ['sda', 'sdc']) to acquire.
+      names(list(str)): list of disk names (eg: ['sda', 'sdc']) to acquire.
     Returns:
       list(DiskArtifact): a sorted (and curated) list of disks to acquire.
     """

--- a/auto_forensicate/recipes/disk.py
+++ b/auto_forensicate/recipes/disk.py
@@ -177,8 +177,7 @@ class MacDiskArtifact(DiskArtifact):
     if self._macdisk.internal and (
         # TODO: this needs more research on how to autodetect "interesting"
         # disks to copy on MacOS.
-        # pylint: disable=protected-access
-        self._macdisk._attributes['VirtualOrPhysical'] != 'Virtual'):
+        self._macdisk.virtualorphysical != 'Virtual'):
       return True
     return False
 

--- a/auto_forensicate/recipes/disk.py
+++ b/auto_forensicate/recipes/disk.py
@@ -22,16 +22,9 @@ import subprocess
 
 from auto_forensicate import errors
 from auto_forensicate import hostinfo
+from auto_forensicate import macdisk
 from auto_forensicate.recipes import base
 from auto_forensicate.ux import gui
-
-try:
-  # This is not in pip, can be installed from:
-  # https://github.com/google/macops/tree/master/gmacpyutil
-  # If not present, code should still run on a Linux machine.
-  from gmacpyutil import macdisk
-except ImportError:
-  pass
 
 
 class DiskArtifact(base.BaseArtifact):

--- a/auto_forensicate/recipes/firmware.py
+++ b/auto_forensicate/recipes/firmware.py
@@ -33,6 +33,10 @@ class ChipsecRecipe(base.BaseRecipe):
     Returns:
       list (BaseArtifact): the artifacts for the system's firmware.
     """
+    if self._platform == 'darwin':
+      self._logger.warn('Firmware acquisition only works on Linux, skipping.')
+      return []
+
     firmware_artifact = base.ProcessOutputArtifact(
         self._CHIPSEC_CMD, 'Firmware/rom.bin')
     return [firmware_artifact]

--- a/auto_forensicate/recipes/sysinfo.py
+++ b/auto_forensicate/recipes/sysinfo.py
@@ -23,6 +23,8 @@ class SysinfoRecipe(base.BaseRecipe):
   """The SysinfoRecipe class."""
 
   _DMI_DECODE_CMD = ['/usr/sbin/dmidecode', '--type=1']
+  _SYSTEM_PROFILER_CMD = [
+      '/usr/sbin/system_profiler', 'SPHardwareDataType', 'SPSoftwareDataType']
 
   def GetArtifacts(self):
     """Provides a list of Artifacts to upload.
@@ -30,7 +32,9 @@ class SysinfoRecipe(base.BaseRecipe):
     Returns:
       list (BaseArtifact): the artifacts corresponding to copy.
     """
-    artifact = base.ProcessOutputArtifact(
-        self._DMI_DECODE_CMD, 'system_info.txt')
-
-    return [artifact]
+    if self._platform == 'darwin':
+      return [
+          base.ProcessOutputArtifact(
+              self._SYSTEM_PROFILER_CMD, 'system_info.txt')]
+    return [
+        base.ProcessOutputArtifact(self._DMI_DECODE_CMD, 'system_info.txt')]

--- a/auto_forensicate/stamp/__init__.py
+++ b/auto_forensicate/stamp/__init__.py
@@ -12,4 +12,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/auto_forensicate/uploader.py
+++ b/auto_forensicate/uploader.py
@@ -28,8 +28,8 @@ try:
   from urlparse import urlparse
 except ImportError:
   from urllib.parse import urlparse
-from auto_forensicate import errors
 import boto
+from auto_forensicate import errors
 
 
 class GCSUploader(object):

--- a/auto_forensicate/ux/__init__.py
+++ b/auto_forensicate/ux/__init__.py
@@ -12,4 +12,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/auto_forensicate/ux/gui.py
+++ b/auto_forensicate/ux/gui.py
@@ -70,4 +70,3 @@ def AskDiskList(disk_list):
   if choices == ['']:
     return []
   return [disk_description_map[choice] for choice in choices]
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ gcs-oauth2-boto-plugin
 google-cloud-logging
 google-cloud-storage
 mock
-plistlib
+biplist
 progress
 six
 http://brianramos.com/software/PyZenity/PyZenity-0.1.8.tar.gz

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ gcs-oauth2-boto-plugin
 google-cloud-logging
 google-cloud-storage
 mock
+plistlib
 progress
 six
 http://brianramos.com/software/PyZenity/PyZenity-0.1.8.tar.gz

--- a/tests/disk_tests.py
+++ b/tests/disk_tests.py
@@ -22,6 +22,7 @@ from auto_forensicate import errors
 from auto_forensicate.recipes import base
 from auto_forensicate.recipes import disk
 import mock
+import gmacpyutil
 
 
 # pylint: disable=missing-docstring
@@ -52,22 +53,25 @@ class DiskArtifactTests(unittest.TestCase):
     d = disk.DiskArtifact(path, 100)
     self.assertEqual(d._GenerateDDCommand(), dd_command)
 
+class LinuxDiskArtifactTests(unittest.TestCase):
+  """Tests for the LinuxDiskArtifact class."""
+
   def testIsFloppy(self):
-    disk_object = disk.DiskArtifact('/dev/sdX', 12345)
+    disk_object = disk.LinuxDiskArtifact('/dev/sdX', 12345)
     disk_object._udevadm_metadata = {'MAJOR': '2'}
     self.assertTrue(disk_object._IsFloppy())
     disk_object._udevadm_metadata = {'MAJOR': '12'}
     self.assertFalse(disk_object._IsFloppy())
 
   def testIsUsb(self):
-    disk_object = disk.DiskArtifact('/dev/sdX', 12345)
+    disk_object = disk.LinuxDiskArtifact('/dev/sdX', 12345)
     disk_object._udevadm_metadata = {'ID_BUS': 'usb'}
     self.assertTrue(disk_object._IsUsb())
     disk_object._udevadm_metadata = {'ID_BUS': 'ata'}
     self.assertFalse(disk_object._IsUsb())
 
   def testProbablyADisk(self):
-    disk_object = disk.DiskArtifact('/dev/sdX', 123456789)
+    disk_object = disk.LinuxDiskArtifact('/dev/sdX', 123456789)
     disk_object._udevadm_metadata = {'ID_BUS': 'ata'}
     self.assertTrue(disk_object.ProbablyADisk())
 
@@ -88,7 +92,7 @@ class DiskArtifactTests(unittest.TestCase):
     self.assertTrue(disk_object.ProbablyADisk())
 
   def testGetDescription(self):
-    disk_object = disk.DiskArtifact('/dev/sdX', 123456789)
+    disk_object = disk.LinuxDiskArtifact('/dev/sdX', 123456789)
     disk_object._udevadm_metadata = {
         'ID_BUS': 'ata',
         'ID_MODEL': 'TestDisk'
@@ -111,7 +115,7 @@ class DiskArtifactTests(unittest.TestCase):
 
 
 class DiskRecipeTests(unittest.TestCase):
-  """Tests for the DiskRecipe class."""
+  """Tests for the DiskRecipe (on linux) class."""
 
   def setUp(self):
     self._lsblk_dict = {
@@ -152,11 +156,13 @@ class DiskRecipeTests(unittest.TestCase):
 
   def testListDisksZero(self):
     recipe = disk.DiskRecipe('Disk')
+    recipe._platform = 'linux'
     disk.DiskRecipe._GetLsblkDict = self._GetLsblkDictZeroDisks
     self.assertEqual(0, len(recipe._ListDisks()))
 
   def testListAllDisks(self):
     recipe = disk.DiskRecipe('Disk')
+    recipe._platform = 'linux'
     disk.DiskRecipe._GetLsblkDict = self._GetLsblkDictThreeDisks
     disk_list = recipe._ListDisks(all_devices=True)
     self.assertEqual(len(disk_list), 3)
@@ -167,6 +173,7 @@ class DiskRecipeTests(unittest.TestCase):
 
   def testListDisksWithNames(self):
     recipe = disk.DiskRecipe('Disk')
+    recipe._platform = 'linux'
     disk.DiskRecipe._GetLsblkDict = self._GetLsblkDictThreeDisks
     disk_list = recipe._ListDisks(all_devices=True, names=['sdz_not_present'])
     self.assertEqual(len(disk_list), 0)
@@ -182,13 +189,14 @@ class DiskRecipeTests(unittest.TestCase):
     ) as patched_listdisk:
       patched_listdisk.return_value = []
       recipe = disk.DiskRecipe('Disk')
+      recipe._platform = 'linux'
       with self.assertRaises(errors.RecipeException):
         recipe.GetArtifacts()
 
   def testGetArtifacts(self):
     disk_name = 'sdx'
     disk_size = 20 * 1024 * 1024 * 1024  # 20GB
-    disk_object = disk.DiskArtifact('/dev/{0:s}'.format(disk_name), disk_size)
+    disk_object = disk.LinuxDiskArtifact('/dev/{0:s}'.format(disk_name), disk_size)
     disk_object._udevadm_metadata = {'udevadm_text_output': 'fake disk info'}
     with mock.patch(
         'auto_forensicate.recipes.disk.DiskRecipe._ListDisks'
@@ -199,15 +207,16 @@ class DiskRecipeTests(unittest.TestCase):
       ) as patched_lsblk:
         patched_lsblk.return_value = self._lsblk_dict
         recipe = disk.DiskRecipe('Disk')
+        recipe._platform = 'linux'
         artifacts = recipe.GetArtifacts()
         self.assertEqual(len(artifacts), 4)
 
-        udevadm_artifact = artifacts[0]
+        udevadm_artifact = artifacts[1]
         self.assertIsInstance(udevadm_artifact, base.StringArtifact)
         self.assertEqual(udevadm_artifact._GetStream().read(), b'fake disk info')
         self.assertEqual(udevadm_artifact.remote_path, 'Disks/sdx.udevadm.txt')
 
-        lsblk_artifact = artifacts[1]
+        lsblk_artifact = artifacts[0]
         self.assertIsInstance(lsblk_artifact, base.StringArtifact)
         self.assertEqual(
             lsblk_artifact._GetStream().read(), json.dumps(self._lsblk_dict).encode('utf-8'))
@@ -220,3 +229,43 @@ class DiskRecipeTests(unittest.TestCase):
         self.assertEqual(file_artifact.name, '{0:s}.hash'.format(disk_name))
         self.assertEqual(
             file_artifact.remote_path, 'Disks/{0:s}.hash'.format(disk_name))
+
+
+class MacDiskArtifactTests(unittest.TestCase):
+  """Tests for the MacDiskArtifact class."""
+
+  def setUp(self):
+    self._fake_disks_list_dict = {
+	'AllDisks': ['diskInternal', 'diskUSB'],
+    }
+    self._fake_disk_infos = {
+	'diskInternal': {
+           'BusProtocol': 'PCI-Express',
+           'Internal': True,
+           'VirtualOrPhysical': 'Unknown',
+	},
+	'diskUSB': {
+           'BusProtocol': 'USB',
+           'Internal': False,
+           'VirtualOrPhysical': 'Physical',
+	}
+    }
+
+  @mock.patch('gmacpyutil.macdisk._DictFromDiskutilInfo')
+  @mock.patch('gmacpyutil.macdisk._DictFromDiskutilList')
+  def testProbablyADisk(self, patched_list_dict, patched_info_dict):
+    patched_list_dict.return_value = self._fake_disks_list_dict
+    patched_info_dict.return_value = self._fake_disk_infos['diskInternal']
+    disk_object = disk.MacDiskArtifact('/dev/diskInternal', 123456789)
+    self.assertTrue(disk_object.ProbablyADisk())
+
+    # We ignore USB to try to avoid copying the GiftStick itself.
+    patched_info_dict.return_value = self._fake_disk_infos['diskUSB']
+    disk_object = disk.MacDiskArtifact('/dev/diskUSB', 123456789)
+    self.assertFalse(disk_object.ProbablyADisk())
+
+  @mock.patch('gmacpyutil.macdisk._DictFromDiskutilInfo')
+  @mock.patch('gmacpyutil.macdisk._DictFromDiskutilList')
+  def testGetDescription(self, patched_list_dict, patched_info_dict):
+    disk_object = disk.MacDiskArtifact('/dev/sdInternal', 123456789)
+    self.assertEqual('Name: sdInternal (Size: 123456789)', disk_object.GetDescription())

--- a/tests/disk_tests.py
+++ b/tests/disk_tests.py
@@ -20,6 +20,8 @@ import json
 import unittest
 import mock
 from auto_forensicate import errors
+#pylint: disable=unused-import
+from auto_forensicate import hostinfo
 from auto_forensicate import macdisk
 from auto_forensicate.recipes import base
 from auto_forensicate.recipes import disk
@@ -44,14 +46,16 @@ class DiskArtifactTests(unittest.TestCase):
     name = 'sdx'
     path = '/dev/{0:s}'.format(name)
     dd_command = [
-        '/usr/bin/dcfldd', 'if={0:s}'.format(path),
+        '/some/place/random/bin/dcfldd', 'if={0:s}'.format(path),
         'hashlog={0:s}.hash'.format(name)]
     dd_static_options = [
         'hash=md5,sha1', 'bs=2M', 'conv=noerror', 'hashwindow=128M']
     dd_command.extend(dd_static_options)
 
-    d = disk.DiskArtifact(path, 100)
-    self.assertEqual(d._GenerateDDCommand(), dd_command)
+    with mock.patch('auto_forensicate.hostinfo.Which') as patched_which:
+      patched_which.return_value = '/some/place/random/bin/dcfldd'
+      d = disk.DiskArtifact(path, 100)
+      self.assertEqual(d._GenerateDDCommand(), dd_command)
 
 class LinuxDiskArtifactTests(unittest.TestCase):
   """Tests for the LinuxDiskArtifact class."""

--- a/tests/disk_tests.py
+++ b/tests/disk_tests.py
@@ -20,6 +20,7 @@ import json
 import unittest
 import mock
 from auto_forensicate import errors
+from auto_forensicate import macdisk
 from auto_forensicate.recipes import base
 from auto_forensicate.recipes import disk
 
@@ -230,47 +231,42 @@ class DiskRecipeTests(unittest.TestCase):
             file_artifact.remote_path, 'Disks/{0:s}.hash'.format(disk_name))
 
 
-try:
-  #pylint: disable=unused-import
-  import gmacpyutil
-  class MacDiskArtifactTests(unittest.TestCase):
-    """Tests for the MacDiskArtifact class."""
+class MacDiskArtifactTests(unittest.TestCase):
+  """Tests for the MacDiskArtifact class."""
 
-    def setUp(self):
-      self._fake_disks_list_dict = {
-          'AllDisks': ['diskInternal', 'diskUSB'],
-      }
-      self._fake_disk_infos = {
-          'diskInternal': {
-              'BusProtocol': 'PCI-Express',
-              'Internal': True,
-              'VirtualOrPhysical': 'Unknown'
-          },
-          'diskUSB': {
-              'BusProtocol': 'USB',
-              'Internal': False,
-              'VirtualOrPhysical': 'Physical'
-          }
-      }
+  def setUp(self):
+    self._fake_disks_list_dict = {
+        'AllDisks': ['diskInternal', 'diskUSB'],
+    }
+    self._fake_disk_infos = {
+        'diskInternal': {
+            'BusProtocol': 'PCI-Express',
+            'Internal': True,
+            'VirtualOrPhysical': 'Unknown'
+        },
+        'diskUSB': {
+            'BusProtocol': 'USB',
+            'Internal': False,
+            'VirtualOrPhysical': 'Physical'
+        }
+    }
 
-    @mock.patch('gmacpyutil.macdisk._DictFromDiskutilInfo')
-    @mock.patch('gmacpyutil.macdisk._DictFromDiskutilList')
-    def testProbablyADisk(self, patched_list_dict, patched_info_dict):
-      patched_list_dict.return_value = self._fake_disks_list_dict
-      patched_info_dict.return_value = self._fake_disk_infos['diskInternal']
-      disk_object = disk.MacDiskArtifact('/dev/diskInternal', 123456789)
-      self.assertTrue(disk_object.ProbablyADisk())
+  @mock.patch('auto_forensicate.macdisk._DictFromDiskutilInfo')
+  @mock.patch('auto_forensicate.macdisk._DictFromDiskutilList')
+  def testProbablyADisk(self, patched_list_dict, patched_info_dict):
+    patched_list_dict.return_value = self._fake_disks_list_dict
+    patched_info_dict.return_value = self._fake_disk_infos['diskInternal']
+    disk_object = disk.MacDiskArtifact('/dev/diskInternal', 123456789)
+    self.assertTrue(disk_object.ProbablyADisk())
 
-      # We ignore USB to try to avoid copying the GiftStick itself.
-      patched_info_dict.return_value = self._fake_disk_infos['diskUSB']
-      disk_object = disk.MacDiskArtifact('/dev/diskUSB', 123456789)
-      self.assertFalse(disk_object.ProbablyADisk())
+    # We ignore USB to try to avoid copying the GiftStick itself.
+    patched_info_dict.return_value = self._fake_disk_infos['diskUSB']
+    disk_object = disk.MacDiskArtifact('/dev/diskUSB', 123456789)
+    self.assertFalse(disk_object.ProbablyADisk())
 
-    @mock.patch('gmacpyutil.macdisk._DictFromDiskutilInfo')
-    @mock.patch('gmacpyutil.macdisk._DictFromDiskutilList')
-    def testGetDescription(self, patched_list_dict, patched_info_dict):
-      disk_object = disk.MacDiskArtifact('/dev/sdInternal', 123456789)
-      self.assertEqual(
-          'Name: sdInternal (Size: 123456789)', disk_object.GetDescription())
-except ImportError:
-  pass
+  @mock.patch('auto_forensicate.macdisk._DictFromDiskutilInfo')
+  @mock.patch('auto_forensicate.macdisk._DictFromDiskutilList')
+  def testGetDescription(self, patched_list_dict, patched_info_dict):
+    disk_object = disk.MacDiskArtifact('/dev/sdInternal', 123456789)
+    self.assertEqual(
+        'Name: sdInternal (Size: 123456789)', disk_object.GetDescription())

--- a/tests/firmware_tests.py
+++ b/tests/firmware_tests.py
@@ -28,6 +28,7 @@ class ChipsecRecipeTests(unittest.TestCase):
 
   def testGetArtifacts(self):
     chipsec_recipe = firmware.ChipsecRecipe('chipsec')
+    chipsec_recipe._platform = 'linux'
     chipsec_recipe._CHIPSEC_CMD = [
         'echo', '-n', self._CHIPSEC_OUTPUT_STRING]
 


### PR DESCRIPTION
Some stuff going on to make the code work on a 'darwin' platform.

The 'disk' acquisition recipe has mainly the most changes, I use [gmacpyutil](https://github.com/google/macops/tree/master/gmacpyutil) to read information about the attached disk from various Mac commands.

DiskArtifact is split into LinuxDiskArtifact and MacDiskArtifact.
_ListDisks() also has some logic split for both platforms.

Please ignore the codefactor issues, I'll fix the leftovers in #36