### PR TITLE
Make biplist an optional dependency, only to be required when running on MacOS

### DIFF
--- a/auto_forensicate/macdisk.py
+++ b/auto_forensicate/macdisk.py
@@ -15,7 +15,13 @@
 """Helper functions to handle Mac OS information."""
 
 import subprocess
-import biplist
+import sys
+try:
+  import biplist
+except ImportError as e:
+  if sys.platform == 'darwin':
+    print('It looks like you are acquiring raw disk on a MacOS platform. \n'
+          'Please install the biplist python module')
 
 
 class MacDiskError(Exception):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,8 @@
-biplist
 boto
 gcs-oauth2-boto-plugin
 google-cloud-logging
 google-cloud-storage
 mock
-biplist
 progress
 six
 http://brianramos.com/software/PyZenity/PyZenity-0.1.8.tar.gz


### PR DESCRIPTION
biplist is only required when running GiftStick on MacOS (and explicitely acquiring raw disk evidence). I feel like this shouldn't be in the requirements.txt file.