### PR TITLE
Pin cachetools version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+cachetools==3.1.1
 boto
 gcs-oauth2-boto-plugin
 google-cloud-logging

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
     license='Apache License, Version 2.0',
     packages=find_packages(),
     install_requires=[
+        'cachetools==3.1.1',  # Because 4.0 breaks on Py2 installs
         'progress',
         'boto',
         'gcs_oauth2_boto_plugin',


### PR DESCRIPTION
See https://github.com/googleapis/google-auth-library-python/issues/414

We pin the cachetools version to not break Py2.7 installs. Which is the case on Ubuntu 18.04 LTS live CDs.

This won't be necessary anymore once we move to 20.04