### PR TITLE
Fix e2e test scripts to work for a xubuntu 20.04 source iso

### DIFF
--- a/config/jenkins/e2e.sh
+++ b/config/jenkins/e2e.sh
@@ -33,6 +33,7 @@ readonly SSH_KEY_PATH="test_key"
 readonly QEMU_SSH_PORT=5555
 
 readonly EVIDENCE_DISK="disk_42.img"
+readonly EVIDENCE_DISK_GSURL="gs://${GCS_BUCKET}/test_data/${EVIDENCE_DISK}"
 readonly EVIDENCE_DISK_MD5_HEX="1e639d0a0b2c718eae71a058582a555e"
 
 
@@ -93,14 +94,17 @@ function setup {
     wget -q -nc -O "${ISO_FILENAME}" "${ISO_TO_REMASTER_URL}"
   fi
 
-  evidence_disk_url=$(normalize_gcs_url "gs://${GCS_BUCKET}/test_data/disk_42.img")
-  msg "Downloading evidence disk from ${evidence_disk_url}"
-  gsutil -q cp "${evidence_disk_url}" "${EVIDENCE_DISK}"
+  if [ ! -f "${EVIDENCE_DISK}" ]; then
+    evidence_disk_url=$(normalize_gcs_url "${EVIDENCE_DISK_GSURL}")
+    msg "Downloading evidence disk from ${evidence_disk_url}"
+    gsutil -q cp "${evidence_disk_url}" "${EVIDENCE_DISK}"
+  fi
+
 }
 
 # Builds a GiftStick image, using the remaster script
 function build_image {
-  bash "${REMASTER_SCRIPT}" \
+  sudo bash "${REMASTER_SCRIPT}" \
     --project "${CLOUD_PROJECT}" \
     --bucket "${GCS_BUCKET}" \
     --skip_gcs \

--- a/config/jenkins/e2e.sh
+++ b/config/jenkins/e2e.sh
@@ -94,6 +94,20 @@ function setup {
     wget -q -nc -O "${ISO_FILENAME}" "${ISO_TO_REMASTER_URL}"
   fi
 
+  if [[ "${ISO_FILENAME}" == *"20.04"* ]] || [[ "${ISO_FILENAME}" == *"focal"* ]] ; then
+    echo "Upgrading initramfs-tools-core to 0.133 to manage the new initrd format"
+    add-apt-repository 'deb http://europe-west1.gce.archive.ubuntu.com/ubuntu/ eoan main'
+    cat >/etc/apt/preferences.d/limit-eoan <<EOAPT
+Package: *
+Pin: release o=Ubuntu,a=eoan
+Pin-Priority: 150
+EOAPT
+
+    apt update -y
+    apt install -y initramfs-tools-bin=0.133ubuntu10
+    apt install -y initramfs-tools-core=0.133ubuntu10
+  fi
+
   if [ ! -f "${EVIDENCE_DISK}" ]; then
     evidence_disk_url=$(normalize_gcs_url "${EVIDENCE_DISK_GSURL}")
     msg "Downloading evidence disk from ${evidence_disk_url}"

--- a/config/jenkins/e2e.sh
+++ b/config/jenkins/e2e.sh
@@ -33,7 +33,6 @@ readonly SSH_KEY_PATH="test_key"
 readonly QEMU_SSH_PORT=5555
 
 readonly EVIDENCE_DISK="disk_42.img"
-readonly EVIDENCE_DISK_GSURL="gs://${GCS_BUCKET}/test_data/${EVIDENCE_DISK}"
 readonly EVIDENCE_DISK_MD5_HEX="1e639d0a0b2c718eae71a058582a555e"
 
 
@@ -292,6 +291,8 @@ function main {
   ISO_TO_REMASTER_URL=$4
 
   readonly GCS_EXPECTED_URL="gs://${GCS_BUCKET}/forensic_evidence/${EXTRA_GCS_PATH}/*/*/"
+
+  readonly EVIDENCE_DISK_GSURL="gs://${GCS_BUCKET}/test_data/${EVIDENCE_DISK}"
 
   # Use the default xubuntu image if non was specified
   if [[ "${ISO_TO_REMASTER_URL}" == "" ]] ; then

--- a/config/jenkins/e2e.sh
+++ b/config/jenkins/e2e.sh
@@ -104,6 +104,7 @@ Pin-Priority: 150
 EOAPT
 
     apt update -y
+    apt install -y lz4
     apt install -y initramfs-tools-bin=0.133ubuntu10
     apt install -y initramfs-tools-core=0.133ubuntu10
   fi

--- a/config/jenkins/e2e.sh
+++ b/config/jenkins/e2e.sh
@@ -62,6 +62,7 @@ function setup {
   sudo apt install --allow-downgrades -y \
     gdisk \
     genisoimage \
+    initramfs-tools-core \
     kpartx \
     jq \
     ovmf \
@@ -71,21 +72,21 @@ function setup {
     syslinux-utils \
     wget
 
-   # Xenial version of grub-efi-amd64-bin: 2.02~beta2-36ubuntu3 doesn't
-   # generate bootable images, for an unknown reason.
-   # Since our current CI environment uses Xenial, let's for installation
-   # of 2.02-2ubuntu8 from bionic hosted on GCE
-   add-apt-repository 'deb http://europe-west1.gce.archive.ubuntu.com/ubuntu/ bionic main'
-   cat >/etc/apt/preferences.d/limit-bionic <<EOAPT
-Package: *
-Pin: release o=Ubuntu,a=bionic
-Pin-Priority: 150
-EOAPT
-
-  apt update -y
-  apt install -y --allow-downgrades grub-common=2.02-2ubuntu8
-  apt install -y --allow-downgrades grub2-common=2.02-2ubuntu8
-  apt install -y --allow-downgrades grub-efi-amd64-bin=2.02-2ubuntu8
+#   # Xenial version of grub-efi-amd64-bin: 2.02~beta2-36ubuntu3 doesn't
+#   # generate bootable images, for an unknown reason.
+#   # Since our current CI environment uses Xenial, let's force installation
+#   # of 2.02-2ubuntu8 from bionic hosted on GCE
+#   add-apt-repository 'deb http://europe-west1.gce.archive.ubuntu.com/ubuntu/ bionic main'
+#   cat >/etc/apt/preferences.d/limit-bionic <<EOAPT
+#Package: *
+#Pin: release o=Ubuntu,a=bionic
+#Pin-Priority: 150
+#EOAPT
+#
+#  apt update -y
+#  apt install -y --allow-downgrades grub-common=2.02-2ubuntu8
+#  apt install -y --allow-downgrades grub2-common=2.02-2ubuntu8
+#  apt install -y --allow-downgrades grub-efi-amd64-bin=2.02-2ubuntu8
 
   if [ ! -f "${ISO_FILENAME}" ]; then
     wget -q -nc -O "${ISO_FILENAME}" "${ISO_TO_REMASTER_URL}"

--- a/config/jenkins/e2e.sh
+++ b/config/jenkins/e2e.sh
@@ -73,22 +73,6 @@ function setup {
     syslinux-utils \
     wget
 
-#   # Xenial version of grub-efi-amd64-bin: 2.02~beta2-36ubuntu3 doesn't
-#   # generate bootable images, for an unknown reason.
-#   # Since our current CI environment uses Xenial, let's force installation
-#   # of 2.02-2ubuntu8 from bionic hosted on GCE
-#   add-apt-repository 'deb http://europe-west1.gce.archive.ubuntu.com/ubuntu/ bionic main'
-#   cat >/etc/apt/preferences.d/limit-bionic <<EOAPT
-#Package: *
-#Pin: release o=Ubuntu,a=bionic
-#Pin-Priority: 150
-#EOAPT
-#
-#  apt update -y
-#  apt install -y --allow-downgrades grub-common=2.02-2ubuntu8
-#  apt install -y --allow-downgrades grub2-common=2.02-2ubuntu8
-#  apt install -y --allow-downgrades grub-efi-amd64-bin=2.02-2ubuntu8
-
   if [ ! -f "${ISO_FILENAME}" ]; then
     wget -q -nc -O "${ISO_FILENAME}" "${ISO_TO_REMASTER_URL}"
   fi

--- a/config/jenkins/e2e.sh
+++ b/config/jenkins/e2e.sh
@@ -104,6 +104,7 @@ Pin-Priority: 150
 EOAPT
 
     apt update -y
+    apt install -y liblz4-1=1.9.1-1
     apt install -y lz4
     apt install -y initramfs-tools-bin=0.133ubuntu10
     apt install -y initramfs-tools-core=0.133ubuntu10

--- a/config/jenkins/e2e.sh
+++ b/config/jenkins/e2e.sh
@@ -62,6 +62,7 @@ function setup {
   sudo apt install --allow-downgrades -y \
     gdisk \
     genisoimage \
+    grub-efi-amd64-bin \
     initramfs-tools-core \
     kpartx \
     jq \

--- a/config/jenkins/e2e_tools.py
+++ b/config/jenkins/e2e_tools.py
@@ -95,12 +95,12 @@ def CheckLsblk(lsblk_path):
   sdb_disk = [
       dev for dev in lsblk_dict['blockdevices'] if dev['name'] == 'sdb'][0]
 
-  assert sdb_disk['size'] == '44040192'
+  assert int(sdb_disk['size']) == 44040192
   children = sorted(
-      [(child['name'], child['maj:min'], child['size'])
+      [(child['name'], child['maj:min'], int(child['size']))
        for child in sdb_disk['children']])
   assert children == [
-      ('sdb1', '8:17', '12582912'), ('sdb2', '8:18', '30408704')]
+      ('sdb1', '8:17', 12582912), ('sdb2', '8:18', 30408704)]
 
 
 def CheckDiskHash(hash_path):

--- a/tools/remaster_scripts/e2e/post-install-root.sh
+++ b/tools/remaster_scripts/e2e/post-install-root.sh
@@ -71,8 +71,7 @@ sed -e '/cdrom/ s/^#*/#/' -i /etc/apt/sources.list
 
 source /etc/lsb-release
 
-newest_ubuntus=("zesty" "artful" "bionic")
-if [[ "${newest_ubuntus[@]}" =~ "${DISTRIB_CODENAME}" ]]; then
+if ! [[ "xenial" == "${DISTRIB_CODENAME}" ]]; then
   ubuntu_fix_systemd
 fi
 

--- a/tools/remaster_scripts/e2e/post-install-root.sh
+++ b/tools/remaster_scripts/e2e/post-install-root.sh
@@ -24,7 +24,7 @@ function ubuntu_remove_packages {
 }
 
 function install_forensication_tools {
-  readonly local CHIPSEC_PKG=( python-dev libffi-dev build-essential gcc nasm )
+  readonly local CHIPSEC_PKG=( python3-dev libffi-dev build-essential gcc nasm )
   readonly local FORENSIC_PKG=( dcfldd )
 
   # install common utils
@@ -32,7 +32,7 @@ function install_forensication_tools {
 }
 
 function install_basic_pkg {
-  readonly local COMMON_UTILS=( git jq python-pip pv openssh-server zenity )
+  readonly local COMMON_UTILS=( git jq python3-pip pv openssh-server zenity )
 
   apt-get -y update
   apt-get -y install "${COMMON_UTILS[@]}"

--- a/tools/remaster_scripts/e2e/post-install-root.sh
+++ b/tools/remaster_scripts/e2e/post-install-root.sh
@@ -56,6 +56,8 @@ function ubuntu_fix_systemd {
   if [[ -f /etc/systemd/resolved.conf ]]; then
     sed -i 's/^#DNSSEC=.*/DNSSEC=no/' /etc/systemd/resolved.conf
   fi
+
+  apt-get -y update
   apt-get -y install libnss-resolve
 }
 

--- a/tools/remaster_scripts/post-install-root.sh
+++ b/tools/remaster_scripts/post-install-root.sh
@@ -62,7 +62,7 @@ function ubuntu_fix_systemd {
   if [[ -f /etc/systemd/resolved.conf ]]; then
     sed -i 's/^#DNSSEC=.*/DNSSEC=no/' /etc/systemd/resolved.conf
   fi
-  apt update
+  apt-get -y update
   apt-get -y install libnss-resolve
 }
 

--- a/tools/remaster_scripts/post-install-root.sh
+++ b/tools/remaster_scripts/post-install-root.sh
@@ -92,8 +92,7 @@ sed -e '/cdrom/ s/^#*/#/' -i /etc/apt/sources.list
 
 source /etc/lsb-release
 
-newest_ubuntus=("zesty" "artful" "bionic")
-if [[ "${newest_ubuntus[@]}" =~ "${DISTRIB_CODENAME}" ]]; then
+if ! [[ "xenial" == "${DISTRIB_CODENAME}" ]]; then
   ubuntu_fix_systemd
 fi
 

--- a/tools/remaster_scripts/post-install-root.sh
+++ b/tools/remaster_scripts/post-install-root.sh
@@ -62,6 +62,7 @@ function ubuntu_fix_systemd {
   if [[ -f /etc/systemd/resolved.conf ]]; then
     sed -i 's/^#DNSSEC=.*/DNSSEC=no/' /etc/systemd/resolved.conf
   fi
+  apt update
   apt-get -y install libnss-resolve
 }
 


### PR DESCRIPTION
In order for the E2E tests to also work on the next LTS ubuntu (20.04/focal) we need to:
- adapt to the new initrd format
- adapt to some weird lsblk output differences

I also removed some old fixes for Xenial that don't have to be there anymore because our CI is running bionic VMs