### PR TITLE
Update README.md - Manual set-up dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ versions of Xubuntu.
 The following packages should be installed in the system you're booting into:
 
 * `sudo apt install dcfldd python-pip zenity`
+* `sudo pip install gcs_oauth2_boto_plugin --upgrade;`
+* `sudo pip install google_cloud_logging --upgrade;`
+* `sudo pip install progress --upgrade;`
 * For Chipsec (optional)
 `apt install python-dev libffi-dev build-essential gcc nasm`
 


### PR DESCRIPTION
gcs_oauth2_boto_plugin, google_cloud_logging and progress python modules need to be upgraded when manually installed. Added that to the dependencies section.