### PR TITLE
Fix tests

### DIFF
--- a/config/jenkins/e2e.sh
+++ b/config/jenkins/e2e.sh
@@ -189,7 +189,6 @@ function normalize_gcs_url {
 function check_stamp {
   local stamp_url
   stamp_url=$(normalize_gcs_url "${GCS_EXPECTED_URL}/stamp.json")
-  echo "check_stamp ${stamp_url}"
   gsutil -q cp "${stamp_url}" stamp.json
   # Check that the stamp is a valid JSON file
   python3 config/jenkins/e2e_tools.py check_stamp stamp.json

--- a/config/jenkins/e2e.sh
+++ b/config/jenkins/e2e.sh
@@ -28,7 +28,7 @@ readonly IMAGE_NAME="giftstick.img"
 readonly DEFAULT_ISO_URL="http://mirror.us.leaseweb.net/ubuntu-cdimage/xubuntu/releases/18.04/release/xubuntu-18.04.1-desktop-amd64.iso"
 
 readonly REMASTER_SCRIPT="tools/remaster.sh"
-readonly EXTRA_GCS_PATH="jenkins-build-${BUILD_NUMBER}"
+readonly EXTRA_GCS_PATH="jenkins-build-${BUILD_TAG}"
 readonly SSH_KEY_PATH="test_key"
 readonly QEMU_SSH_PORT=5555
 
@@ -188,7 +188,6 @@ function normalize_gcs_url {
 # the proper information.
 function check_stamp {
   local stamp_url
-  echo "check_stamp ${stamp_url}"
   stamp_url=$(normalize_gcs_url "${GCS_EXPECTED_URL}/stamp.json")
   echo "check_stamp ${stamp_url}"
   gsutil -q cp "${stamp_url}" stamp.json

--- a/config/jenkins/e2e.sh
+++ b/config/jenkins/e2e.sh
@@ -188,7 +188,9 @@ function normalize_gcs_url {
 # the proper information.
 function check_stamp {
   local stamp_url
+  echo "check_stamp ${stamp_url}"
   stamp_url=$(normalize_gcs_url "${GCS_EXPECTED_URL}/stamp.json")
+  echo "check_stamp ${stamp_url}"
   gsutil -q cp "${stamp_url}" stamp.json
   # Check that the stamp is a valid JSON file
   python3 config/jenkins/e2e_tools.py check_stamp stamp.json

--- a/tools/remaster_scripts/call_auto_forensicate.sh
+++ b/tools/remaster_scripts/call_auto_forensicate.sh
@@ -26,6 +26,11 @@ fi
 
 source config.sh
 
+
+# For some reason letting this package be installed with setup.py with
+# call_autofirensicate.sh can sometimes exhaust all memory, doing it here.
+sudo pip3 install grpcio
+
 # Make sure have the latest version of the auto_forensicate module
 git clone https://github.com/google/GiftStick
 cd GiftStick


### PR DESCRIPTION
For some reasons the installation of dependencies would crash, so we install grpcio separately.
We also need to separate between jobs better with the whole project name rather than job number so as to avoid collisions when uploading to GCS