### PR TITLE
Undo initrd customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ with the proper roles & ACL.
 acquisition process.
 
 It needs as input :
-* a vanilla Ubuntu ISO (tested with XUbuntu 20.04)
+* a [Xubuntu 20.04 ISO](https://xubuntu.org/download/) (won't work with non-XUbuntu, untested with versions different than 20.04)
 * the name of your GCP project
 * the name of the GCS bucket (remember those need to be globally unique)
 
@@ -42,7 +42,7 @@ in](https://cloud.google.com/sdk/docs/initializing). Then run:
 bash tools/remaster.sh \
   --project some-forensics-project-XYZ \
   --bucket giftstick-uploads-XYZ
-  --source_iso gift_stick/xubuntu-20.04-desktop-amd64.iso
+  --source_iso xubuntu-20.04-desktop-amd64.iso
 ```
 
 

--- a/config/jenkins/e2e.sh
+++ b/config/jenkins/e2e.sh
@@ -22,7 +22,7 @@ SA_CREDENTIALS_FILE=""
 ISO_TO_REMASTER_URL=""
 ISO_FILENAME=""
 
-readonly GIFT_USER="gift"
+readonly GIFT_USER="xubuntu"
 readonly IMAGE_NAME="giftstick.img"
 
 readonly DEFAULT_ISO_URL="http://mirror.us.leaseweb.net/ubuntu-cdimage/xubuntu/releases/18.04/release/xubuntu-18.04.1-desktop-amd64.iso"
@@ -169,7 +169,7 @@ function run_image {
 
 # Starts the acquisition script
 function run_acquisition_script {
-  ssh_and_run "cd /home/gift ; sudo bash /home/gift/call_auto_forensicate.sh"
+  ssh_and_run "cd /home/${GIFT_USER} ; sudo bash call_auto_forensicate.sh"
 }
 
 # Checks whether a GCS object exists.

--- a/tools/commons.sh
+++ b/tools/commons.sh
@@ -17,7 +17,7 @@
 # scripts in this directory.
 
 readonly CURRENT_DIR=$(pwd)
-readonly GIFT_USERNAME="gift"
+readonly GIFT_USERNAME="xubuntu"
 readonly REMASTER_WORKDIR_NAME="remaster_workdir"
 readonly REMASTER_WORKDIR_PATH=$(readlink -m "${CURRENT_DIR}/${REMASTER_WORKDIR_NAME}")
 readonly REMASTER_SCRIPTS_DIR="${CODE_DIR}/remaster_scripts"

--- a/tools/remaster.sh
+++ b/tools/remaster.sh
@@ -113,11 +113,11 @@ EOBANNER
 function show_usage {
   echo "
 Usage: remaster.sh [OPTIONS]
-Generates a new GiftStick image. Complete usage doc at go/giftstick
+Generates a new GiftStick image.
 
 Example use:
 
-  bash remaster.sh --source_iso xubuntu-18.04-desktop-amd64.iso --project your_gcp_project --bucket gcs_bucketname
+  bash remaster.sh --source_iso xubuntu-20.04-desktop-amd64.iso --project your_gcp_project --bucket gcs_bucketname
 
 Mandatory flags:
   --source_iso=ISO      The vanilla LiveCD to use as a base for the Gift OS
@@ -154,6 +154,11 @@ function assert_sourceiso_flag {
     fi
     if [[ ! -f "${FLAGS_SOURCE_ISO}" ]]; then
       die "${FLAGS_SOURCE_ISO} is not found"
+    fi
+    if [[ "${FLAGS_SOURCE_ISO}" != *xubuntu* ]]; then
+      echo "WARNING: This auto-remastering tool will probably not behave properly on a non xubuntu image"
+      echo "press enter to continue anyway."
+      read -r
     fi
     SOURCE_ISO=$(readlink -m "${FLAGS_SOURCE_ISO}")
   else
@@ -496,69 +501,9 @@ function chroot_rootfs {
   unmount_pseudo_fs "${chroot_dir}"
 }
 
-# Builds a new initrd file
-#
-# Arguments:
-#  The unpacked ISO directory, containing the compressed /casper/initrd file, as
-#    string.
-#  The target directory, as string.
-function pack_initrd {
-  local -r unpacked_iso_dir=$1
-  local -r initrd_dir=$2
-  msg "Packing new initrd from ${unpacked_iso_dir}/casper/initrd.* to ${initrd_dir}"
-
-  local initrd_file
-  local initrd_pack_method
-
-  pushd "${initrd_dir}"
-  if [[ -e "${unpacked_iso_dir}/casper/initrd.lz" ]]; then
-    initrd_file="${unpacked_iso_dir}/casper/initrd.lz"
-    initrd_pack_method=lzma
-  elif [[ -e "${unpacked_iso_dir}/casper/initrd.gz" ]]; then
-    initrd_file="${unpacked_iso_dir}/casper/initrd.gz"
-    initrd_pack_method=gzip
-  elif [[ -e "${unpacked_iso_dir}/install/initrd.gz" ]]; then
-    initrd_file="${unpacked_iso_dir}/install/initrd.gz"
-    initrd_pack_method=gzip
-  elif [[ -e "${unpacked_iso_dir}/casper/initrd" ]]; then
-    initrd_file="${unpacked_iso_dir}/casper/initrd.lz"
-    initrd_pack_method=lzma
-  else
-    die "Can't find initrd file"
-  fi
-  find . | cpio -H newc -o | ${initrd_pack_method} > "${REMASTER_WORKDIR_PATH}/initrd.packed"
-  sudo mv -f "${REMASTER_WORKDIR_PATH}/initrd.packed" "${initrd_file}"
-  popd
-}
-
-# Unpacks a initrd file.
-#
-# Arguments:
-#  The unpacked ISO directory, containing the compressed /casper/initrd file, as
-#    string.
-#  The target directory, as string.
-function unpack_initrd {
-  local -r unpacked_iso_dir=$1
-  local -r initrd_dir=$2
-
-  local initrd_file
-
-  msg "Unpacking initrd to modify casper"
-
-  if [[ -e "${unpacked_iso_dir}/casper/initrd.lz" ]]; then
-    initrd_file="${unpacked_iso_dir}/casper/initrd.lz"
-  elif [[ -e "${unpacked_iso_dir}/casper/initrd" ]]; then
-    initrd_file="${unpacked_iso_dir}/casper/initrd"
-  fi
-
-  mkdir "${initrd_dir}"
-  unmkinitramfs "${initrd_file}"  "${initrd_dir}"
-}
-
 # Cleans up all remastering working directories.
 function clean_all_remaster_directories {
   msg "Cleaning up"
-  sudo rm -rf "${remaster_initrd_dir}"
   unmount_pseudo_fs "${remaster_destroot_dir}"
   sudo rm -rf "${remaster_destroot_dir}"
   sudo rm -rf "${remaster_destiso_dir}"
@@ -572,7 +517,6 @@ function make_custom_ubuntu_iso {
   readonly remaster_destroot_dir="${REMASTER_WORKDIR_PATH}/remaster-root"
   readonly remaster_destsquashfs_dir="${remaster_destiso_dir}/squashfs"
 
-  local remaster_initrd_dir="${REMASTER_WORKDIR_PATH}/remaster-initrd"
   local post_ubuntu_script_name
 
   msg "Making a custom ISO image from $(basename "${SOURCE_ISO}")"
@@ -580,21 +524,6 @@ function make_custom_ubuntu_iso {
   unpack_iso "${SOURCE_ISO}" "${remaster_destiso_dir}"
   mkdir "${remaster_destroot_dir}"
   unpack_rootfs "${remaster_destiso_dir}" "${remaster_destroot_dir}"
-  unpack_initrd "${remaster_destiso_dir}" "${remaster_initrd_dir}"
-
-  if [[ -d "${remaster_initrd_dir}/main" ]] ; then
-    remaster_initrd_dir="${remaster_initrd_dir}/main"
-  fi
-
-  msg "Customizing initrd"
-  sudo sed -i "s/USERNAME=\".*\"$/USERNAME=\"${GIFT_USERNAME}\"/" \
-    "${remaster_initrd_dir}/etc/casper.conf"
-  sudo sed -i "s/HOST=\".*\"$/HOST=\"gift-stick\"/" \
-    "${remaster_initrd_dir}/etc/casper.conf"
-  echo "export FLAVOUR=\"GIFTSTICK\"" | \
-    sudo tee -a "${remaster_initrd_dir}/etc/casper.conf"
-
-  pack_initrd "${remaster_destiso_dir}" "${remaster_initrd_dir}"
 
   if [[ -f "${POST_UBUNTU_ROOT_SCRIPT}" ]] ; then
     post_ubuntu_script_name=$(basename "${POST_UBUNTU_ROOT_SCRIPT}")
@@ -740,15 +669,8 @@ function make_bootable_usb_image {
   msg "Install some GRUB Magic"
   # Fix for the "no suitable mode found" error
   sudo cp /usr/share/grub/unicode.pf2 "${TMP_MNT_POINT}/boot/grub/"
-
-  if [[ ${remastered_iso_filename} == *"xubuntu"* ]]; then
-    # Xubuntu uses a specific name for the kernel file.
-    if [[ ${remastered_iso_filename} == *"18.04"* ]]; then
-      kernel_name="vmlinuz"
-    else
-      kernel_name="vmlinuz.efi"
-    fi
-  fi
+  msg "wait"
+  read
 
   cat << EOGRUB | sudo tee "${TMP_MNT_POINT}/boot/grub/grub.cfg" > /dev/null
 set default=0
@@ -770,8 +692,8 @@ fi
 menuentry 'Ubuntu/Gift' {
   set isofile="/iso/${remastered_iso_filename}"
   loopback loop \$isofile
-  linux (loop)/casper/${kernel_name} boot=casper iso-scan/filename=\$isofile liveimg noprompt noeject quiet splash persistent --
-  initrd (loop)/casper/initrd.lz
+  linux (loop)/casper/vmlinuz boot=casper iso-scan/filename=\$isofile liveimg noprompt noeject quiet splash persistent --
+  initrd (loop)/casper/initrd
 }
 EOGRUB
 

--- a/tools/remaster.sh
+++ b/tools/remaster.sh
@@ -669,8 +669,6 @@ function make_bootable_usb_image {
   msg "Install some GRUB Magic"
   # Fix for the "no suitable mode found" error
   sudo cp /usr/share/grub/unicode.pf2 "${TMP_MNT_POINT}/boot/grub/"
-  msg "wait"
-  read
 
   cat << EOGRUB | sudo tee "${TMP_MNT_POINT}/boot/grub/grub.cfg" > /dev/null
 set default=0


### PR DESCRIPTION
This keeps breaking with new versions of ubuntu and various ways the boot process is done.
I'm removing this part, which means the current username for the livecd is now "xubuntu". This shouldn't impact the end user of a gift stick image as they still would just double click on the "forensicate!"  button

This also means the remastering script will only work with Xubuntu ISOs, and doc is updated accordingly