### PR TITLE
Convert output of zenity AskText() to str()

### DIFF
--- a/auto_forensicate/ux/gui.py
+++ b/auto_forensicate/ux/gui.py
@@ -32,7 +32,7 @@ def AskText(message, mandatory=False):
     while not text:
       text = zenity.GetText(message)
   # TODO: Sanitize input here, as this will be used to construct GCS paths.
-  return text
+  return text.decode()
 
 
 def AskDiskList(disk_list):


### PR DESCRIPTION
Zenity returns bytes() instead of str()