### PR TITLE
Add a dependency check for syslinux-utils in remastering scripts

### DIFF
--- a/tools/remaster.sh
+++ b/tools/remaster.sh
@@ -26,7 +26,8 @@
 # you specify the destination with --image
 #
 # It requires the following packages, on ubuntu:
-#   gdisk genisoimage grub-efi-amd64-bin syslinux initramfs-tools-core
+#   gdisk genisoimage grub-efi-amd64-bin syslinux syslinux-utils
+#   initramfs-tools-core
 #
 # gdisk and grub-efi-amd64-bin are used for the EFI booting part.
 #
@@ -760,6 +761,7 @@ function main {
   check_packages grub-efi-amd64-bin
   check_packages squashfs-tools
   check_packages syslinux
+  check_packages syslinux-utils
   set -e
 
   parse_arguments "$@"


### PR DESCRIPTION
Currently remaster.sh fails to complete on a standard Debian/Ubuntu build as isohybrid is now included with the syslinux-utils package rather than syslinux. Added a check_packages check for syslinux-utils along with the other checks, this resolves #59.