### PR TITLE
Change Stackdriver logging source

### DIFF
--- a/auto_forensicate/auto_acquire.py
+++ b/auto_forensicate/auto_acquire.py
@@ -26,7 +26,6 @@ import time
 import gcs_oauth2_boto_plugin  # pylint: disable=unused-import
 from google.cloud import logging as google_logging
 from google.cloud.logging.handlers import CloudLoggingHandler
-from google.cloud.logging.handlers import setup_logging as setup_gcp_logging
 from google.oauth2 import service_account
 from progress.bar import IncrementalBar
 from progress.spinner import Spinner

--- a/auto_forensicate/auto_acquire.py
+++ b/auto_forensicate/auto_acquire.py
@@ -208,11 +208,11 @@ class AutoForensicate(object):
           options.gs_keyfile)
       project_id = self._gcs_settings.get('project_id', None)
 
-      gcp_client_logger = google_logging.Client(
+      gcp_logging_client = google_logging.Client(
           project=project_id, credentials=gcp_credentials)
       self._stackdriver_handler = CloudLoggingHandler(
-          gcp_client_logger, name='GiftStick')
-      setup_gcp_logging(self._stackdriver_handler)
+          gcp_logging_client, name='GiftStick')
+      self._logger.addHandler(self._stackdriver_handler)
 
   def _MakeUploader(self, options):
     """Creates a new Uploader object.


### PR DESCRIPTION
Currently when Stackdriver logging is enabled, rather than logging what is explicitly logged with AutoForensicate's logger, it captures logging produced by all Python modules by registering as a handler for the root Python logger.

This appears to be causing issue #99 where output is duplicated on the local console when Stackdriver logging is enabled.

The proposed change will configure Stackdriver logging to only capture what is explicitly logged wtih AutoForensicate's logger. Resolves #99