### PR TITLE
Add Stackdriver progress reporting functionality

### DIFF
--- a/auto_forensicate/auto_acquire.py
+++ b/auto_forensicate/auto_acquire.py
@@ -46,24 +46,20 @@ VALID_RECIPES = {
 
 ARTIFACT_MIN_REPORTING_SIZE = 1024**3
 
-def HumanReadableBytes(byte_val, base=10):
+def HumanReadableBytes(byte_val, prefix='dec'):
   """Converts a byte count into a human readable form in MB/MiB etc
 
   Args:
     byte_val (int): a byte count.
-    base (int): what numbering base to use can be either 2 or 10
+    prefix (str): what prefix system to use, bin (KiB) or dec (KB)
   Returns:
     str: A human-readable byte count.
-  Raises:
-    ValueError: if a base other than 2 or 10 is given.
   """
-  if base not in (2, 10):
-    raise ValueError('base must be 2 or 10')
 
-  if base == 2:
+  if prefix == 'bin':
     kilo = 1024
     suffixes = ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB']
-  else:
+  elif prefix == 'dec':
     kilo = 1000
     suffixes = ['B', 'KB', 'MB', 'GB', 'TB', 'PB']
 
@@ -181,7 +177,7 @@ class GCPProgressReporter:
       self._progress_logger.log_text(
           'Uploading \'{:s}\' ({:d}% - {:s} remaining)'.format(
               self._artifact.name, percentage,
-              HumanReadableBytes(bytes_remaining, 2)),
+              HumanReadableBytes(bytes_remaining, 'bin')),
           severity='INFO')
       self._reported_percentage = percentage
 

--- a/auto_forensicate/auto_acquire.py
+++ b/auto_forensicate/auto_acquire.py
@@ -158,13 +158,13 @@ class UpdateCallbackHandler:
     Returns:
       str: A human-readable byte count.
     """
-    suffixes = ['bytes', 'KiB', 'MiB', 'GiB', 'TiB']
+    suffixes = ['B', 'KiB', 'MiB', 'GiB', 'TiB']
     for i in range(4, 0, -1):
       if size >= 1024**i:
         return '{:.1f}{:s}'.format(size / 1024**i, suffixes[i])
     return '{:.1f}{:s}'.format(0, suffixes[0])
 
-  def _IsReportable(self, percentage):
+  def _CheckReportable(self, percentage):
     """Returns a bool indicating if the current percentage shoud be reported.
 
     Args:
@@ -187,7 +187,7 @@ class UpdateCallbackHandler:
     percentage = int(current_bytes / self._artifact.size * 100)
     bytes_remaining = self._artifact.size - current_bytes
 
-    if self._IsReportable(percentage):
+    if self._CheckReportable(percentage):
       self._progress_logger.log_text(
           'Uploading \'{:s}\' ({:d}% - {:s} remaining)'.format(
               self._artifact.name, percentage,
@@ -205,7 +205,7 @@ class UpdateCallbackHandler:
     """
     self._progress_bar.update_with_total(current_bytes, _unused_total_bytes)
     if self._progress_reporting:
-      self._LogProcess(current_bytes)
+      self._LogProgress(current_bytes)
 
 
 

--- a/auto_forensicate/auto_acquire.py
+++ b/auto_forensicate/auto_acquire.py
@@ -159,7 +159,10 @@ class UpdateCallbackHandler:
       str: A human-readable byte count.
     """
     suffixes = ['B', 'KiB', 'MiB', 'GiB', 'TiB']
-    for i in range(4, 0, -1):
+
+    if size == 1:
+      return '{:.1f}{:s}'.format(1, suffixes[0])
+    for i in range(4, -1, -1):
       if size >= 1024**i:
         return '{:.1f}{:s}'.format(size / 1024**i, suffixes[i])
     return '{:.1f}{:s}'.format(0, suffixes[0])
@@ -175,8 +178,7 @@ class UpdateCallbackHandler:
     if percentage % self._reporting_frequency == 0:
       if percentage != self._reported_percentage:
         return True
-    else:
-      return False
+    return False
 
   def _LogProgress(self, current_bytes):
     """Log the current progress.

--- a/auto_forensicate/auto_acquire.py
+++ b/auto_forensicate/auto_acquire.py
@@ -141,6 +141,7 @@ class AutoForensicate(object):
     self._errors = []
     self._gcs_settings = None
     self._logger = None
+    self._progress_logger = None
     self._recipes = recipes
     self._uploader = None
     self._should_retry = False  # True when a recoverable error occurred.
@@ -175,6 +176,12 @@ class AutoForensicate(object):
         '--logging', action='append', required=False,
         choices=['stackdriver', 'stdout'], default=['stdout'],
         help='Selects logging methods.'
+    )
+    parser.add_argument(
+        '--log_progress', action='store_true', default=False,
+        help=(
+            'Enable logging of acquisition progress to stackdriver, requires '
+            'stackdriver to be selected with --logging')
     )
     parser.add_argument(
         '--select_disks', action='store_true', required=False, default=False,
@@ -213,6 +220,10 @@ class AutoForensicate(object):
       self._stackdriver_handler = CloudLoggingHandler(
           gcp_logging_client, name='GiftStick')
       self._logger.addHandler(self._stackdriver_handler)
+
+      if options.log_progress:
+        self._progress_logger = google_logging.logger.Logger(
+            'GiftStick', gcp_logging_client)
 
   def _MakeUploader(self, options):
     """Creates a new Uploader object.

--- a/auto_forensicate/auto_acquire.py
+++ b/auto_forensicate/auto_acquire.py
@@ -459,7 +459,7 @@ class AutoForensicate(object):
       artifact (BaseArtifact): the artifact representing the file to upload.
 
     Returns:
-      ProgressBar: the progress bar object.
+      ProgressReporter: the progress reporter object.
     """
     if self._progress_logger:
       if artifact.size > MIN_REPORTING_SIZE:

--- a/auto_forensicate/auto_acquire.py
+++ b/auto_forensicate/auto_acquire.py
@@ -142,8 +142,8 @@ class UpdateCallbackHandler:
     self._progress_bar = progress_bar
     self._artifact = artifact
     self._progress_logger = progress_logger
-    self._reporting_frequency = 5 # Report every 5% of progress
-    self._min_reporting_size = 1024**3 # Only report progress for > 1GiB
+    self._reporting_frequency = 5  # Report every 5% of progress
+    self._min_reporting_size = 1024**3  # Only report progress for > 1GiB
     self._reported_percentage = 0
     self._progress_reporting = False
 
@@ -206,7 +206,6 @@ class UpdateCallbackHandler:
     self._progress_bar.update_with_total(current_bytes, _unused_total_bytes)
     if self._progress_reporting:
       self._LogProgress(current_bytes)
-
 
 
 class AutoForensicate(object):

--- a/tests/auto_forensicate_tests.py
+++ b/tests/auto_forensicate_tests.py
@@ -97,12 +97,8 @@ class FakeGoogleLogger(object):
 class HumanReadableBytesTest(unittest.TestCase):
   """Tests for the HumanReadableBytes Function"""
 
-  def testBadBase(self):
-    with self.assertRaises(ValueError):
-      auto_acquire.HumanReadableBytes(0, 3)
-
-  def testBase10(self):
-    """Tests base10 based conversions"""
+  def testDec(self):
+    """Tests decimal prefix based conversions"""
 
     self.assertEqual(auto_acquire.HumanReadableBytes(0.0), '0.0 B')
     expected = [
@@ -118,17 +114,17 @@ class HumanReadableBytesTest(unittest.TestCase):
       self.assertEqual(
           auto_acquire.HumanReadableBytes(1.23 * (10 ** index)), value)
 
-  def testBase2(self):
-    """Tests base2 based conversions"""
+  def testBin(self):
+    """Tests binary prefix based conversions"""
 
     self.assertEqual(auto_acquire.HumanReadableBytes(
-        1024**1 - 1024**0, 2), '1023.0 B')
+        1024**1 - 1024**0, 'bin'), '1023.0 B')
     self.assertEqual(auto_acquire.HumanReadableBytes(
-        1024**1, 2), '1.0 KiB')
+        1024**1, 'bin'), '1.0 KiB')
     self.assertEqual(auto_acquire.HumanReadableBytes(
-        1024**4 - 1024**3, 2), '1023.0 GiB')
+        1024**4 - 1024**3, 'bin'), '1023.0 GiB')
     self.assertEqual(auto_acquire.HumanReadableBytes(
-        1024**4, 2), '1.0 TiB')
+        1024**4, 'bin'), '1.0 TiB')
 
 
 class GCPProgressReporterTest(unittest.TestCase):

--- a/tests/auto_forensicate_tests.py
+++ b/tests/auto_forensicate_tests.py
@@ -117,10 +117,10 @@ class BarTest(unittest.TestCase):
 
 
 class ProgressReporterTest(unittest.TestCase):
-  """Tests for the UpdateCallbackHandler class."""
+  """Tests for the ProgressReporter class."""
 
   def setUp(self):
-    """Set up an instantiated UpdateCallbackHandler for each test"""
+    """Set up an instantiated ProgressReporter for each test"""
     self.progress_reporter = auto_acquire.ProgressReporter(
         BytesIORecipe('stringio').GetArtifacts()[0],
         FakeGoogleLogger())

--- a/tests/auto_forensicate_tests.py
+++ b/tests/auto_forensicate_tests.py
@@ -116,19 +116,18 @@ class BarTest(unittest.TestCase):
           progressbar._HumanReadableSpeed(1.23 * (10 ** index)), value)
 
 
-class UpdateCallbackHandlerTest(unittest.TestCase):
+class ProgressReporterTest(unittest.TestCase):
   """Tests for the UpdateCallbackHandler class."""
 
   def setUp(self):
     """Set up an instantiated UpdateCallbackHandler for each test"""
-    self.update_callback_handler = auto_acquire.UpdateCallbackHandler(
-        auto_acquire.BaBar(),
+    self.progress_reporter = auto_acquire.ProgressReporter(
         BytesIORecipe('stringio').GetArtifacts()[0],
         FakeGoogleLogger())
 
   def testHumanReadableSize(self):
     """Tests _HumanReadableSize."""
-    HumanReadableSize = self.update_callback_handler._HumanReadableSize
+    HumanReadableSize = self.progress_reporter._HumanReadableSize
 
     self.assertEqual(HumanReadableSize(0), '0.0B')
     self.assertEqual(HumanReadableSize(1), '1.0B')
@@ -140,26 +139,25 @@ class UpdateCallbackHandlerTest(unittest.TestCase):
 
   def testCheckReportable(self):
     """Tests _CheckReportable."""
-    reporting_frequency = self.update_callback_handler._reporting_frequency
-    CheckReportable = self.update_callback_handler._CheckReportable
+    reporting_frequency = self.progress_reporter._reporting_frequency
+    CheckReportable = self.progress_reporter._CheckReportable
 
     self.assertEqual(CheckReportable(0), False)
     self.assertEqual(CheckReportable(reporting_frequency), True)
-    self.update_callback_handler._reported_percentage = reporting_frequency
+    self.progress_reporter._reported_percentage = reporting_frequency
     self.assertEqual(CheckReportable(reporting_frequency), False)
     self.assertEqual(CheckReportable(reporting_frequency*2), True)
 
   def testLogProgress(self):
     """Tests _LogProgress."""
-    # For reporting purposes set the artifact to 1MiB and enable reporting
-    self.update_callback_handler._artifact = base.StringArtifact(
+    # For reporting purposes set the artifact to 1MiB
+    self.progress_reporter._artifact = base.StringArtifact(
         'fake/path', 'A' * (1024**2))
-    self.update_callback_handler._progress_reporting = True
 
-    artifact = self.update_callback_handler._artifact
-    update_callback = self.update_callback_handler.update_with_total
-    logger = self.update_callback_handler._progress_logger
-    reporting_frequency = self.update_callback_handler._reporting_frequency
+    artifact = self.progress_reporter._artifact
+    update_callback = self.progress_reporter.update_with_total
+    logger = self.progress_reporter._progress_logger
+    reporting_frequency = self.progress_reporter._reporting_frequency
     expected_log_entries = 100 // reporting_frequency
 
     gcs_uploader = GCSUploader()


### PR DESCRIPTION
Add Stackdriver progress reporting functionality that can be enabled with a `--log_progress` argument, requiring Stackdriver logging to be enabled.

When enabled, it will log every 5% of progress to Stackdriver logs like so:
![Screenshot 2020-07-21 at 18 16 20](https://user-images.githubusercontent.com/34120953/88019688-6fc94280-cb7e-11ea-95d5-8e58de064548.png)
