### PR TITLE
Mark firmware recipe as optional

### DIFF
--- a/auto_forensicate/recipes/base.py
+++ b/auto_forensicate/recipes/base.py
@@ -184,12 +184,14 @@ class FileArtifact(BaseArtifact):
 class ProcessOutputArtifact(BaseArtifact):
   """Class for an artifact to upload the output of a command."""
 
-  def __init__(self, command, path):
+  def __init__(self, command, path, ignore_failure=False):
     """Initializes a ProcessOutputArtifact object.
 
     Args:
       command (list): the command to run as subprocess.
       path (str): the remote path to store the output of the command.
+      ignore_failure(bool): set to True to not raise if the command failed to
+        run.
 
     Raises:
       errors.RecipeException: if the command failed to run.
@@ -198,6 +200,7 @@ class ProcessOutputArtifact(BaseArtifact):
     self.remote_path = path
     self._buffered_content = None
     self._command = command
+    self._ignore_failure = ignore_failure
 
   def _RunCommand(self):
     """Run a command.
@@ -221,8 +224,9 @@ class ProcessOutputArtifact(BaseArtifact):
               self._command, error.strip(), process.returncode))
       self._logger.error(command_output)
       command_output = command_output.encode()
-      raise errors.RecipeException(
-          'Error running ProcessOutputArtifact command')
+      if not self._ignore_failure:
+        raise errors.RecipeException(
+            'Error running ProcessOutputArtifact command')
 
     return command_output
 

--- a/auto_forensicate/recipes/base.py
+++ b/auto_forensicate/recipes/base.py
@@ -190,7 +190,7 @@ class ProcessOutputArtifact(BaseArtifact):
     Args:
       command (list): the command to run as subprocess.
       path (str): the remote path to store the output of the command.
-      ignore_failure(bool): set to True to not raise if the command failed to
+      ignore_failure (bool): set to True to not raise if the command failed to
         run.
 
     Raises:

--- a/auto_forensicate/recipes/firmware.py
+++ b/auto_forensicate/recipes/firmware.py
@@ -35,6 +35,9 @@ class ChipsecRecipe(base.BaseRecipe):
       self._logger.info('Firmware acquisition only works on Linux, skipping.')
       return []
 
+    # Firmware acquisition will fail on various platforms (ie: QEMU during e2e
+    # tests, and shouldn't be a reason to mark the full upload as failed.
+    # So we're setting ignore_failure to True.
     firmware_artifact = base.ProcessOutputArtifact(
-        self._CHIPSEC_CMD, 'Firmware/rom.bin')
+        self._CHIPSEC_CMD, 'Firmware/rom.bin', ignore_failure=True)
     return [firmware_artifact]


### PR DESCRIPTION
After fixing error reporting, the firmware acquisition recipe fails on E2E tests (due to them running on QEMU). This marks the whole upload as failed, which marks the test as failed.

We're setting a new option for the ProcessOutputRecipe to not raise (but log an error)